### PR TITLE
Fix switch state updates to avoid async thread safety error

### DIFF
--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -7,19 +7,19 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.restore_state import RestoreEntity
 
 # Setup platform function
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
-    add_entities: AddEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None
 ) -> None:
     """Set up the switch platform."""
     # Retrieve the room information from the shared data
-    ags_config = hass.data['ags_service']
-    rooms = ags_config['rooms']
+    ags_config = hass.data["ags_service"]
+    rooms = ags_config["rooms"]
 
     # Add the switch entities
-    add_entities([RoomSwitch(hass, room) for room in rooms] )
+    async_add_entities([RoomSwitch(hass, room) for room in rooms])
 
 class RoomSwitch(SwitchEntity, RestoreEntity):
     """Representation of a Switch for each Room."""
@@ -44,17 +44,17 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         """Return true if the switch is on."""
         return self._attr_is_on
 
-    def turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         self._attr_is_on = True
         self.hass.data[self._attr_unique_id] = True
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         self._attr_is_on = False
         self.hass.data[self._attr_unique_id] = False
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
 
     async def async_added_to_hass(self):
         """Run when entity about to be added to hass."""


### PR DESCRIPTION
## Summary
- update switch platform to use `async_setup_platform`
- implement `async_turn_on` and `async_turn_off` to update state on the event loop

## Testing
- `python -m py_compile custom_components/ags_service/switch.py`
- `python -m py_compile custom_components/ags_service/media_player.py`
- `python -m py_compile custom_components/ags_service/ags_service.py`
- `python -m py_compile custom_components/ags_service/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_68589f25a9388330bb796a07d62c9fa5