### PR TITLE
Improve AGS playback triggers

### DIFF
--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -91,7 +91,8 @@ async def async_setup(hass, config):
         'create_sensors': ags_config.get(CONF_CREATE_SENSORS, False),
         'default_on': ags_config.get(CONF_DEFAULT_ON, False),
         'static_name': ags_config.get(CONF_STATIC_NAME, None), 
-        'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False) 
+        'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
+        'switch_media_system_state': ags_config.get(CONF_DEFAULT_ON, False)
     }
     ...
 

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -114,13 +114,14 @@ def update_ags_status(ags_config, hass):
 
     media_system_state = hass.data.get('switch_media_system_state')
     if media_system_state is None:
-        if  ags_config['default_on']: 
+        if ags_config['default_on']:
             ags_status = "ON"
         else:
             ags_status = "OFF"
 
         hass.data['ags_status'] = ags_status
         hass.data['media_system_state'] = ags_config['default_on']
+        hass.data['switch_media_system_state'] = ags_config['default_on']
         return ags_status
 
     if not media_system_state:
@@ -392,9 +393,13 @@ def ags_select_source(ags_config, hass):
             source_info = source_dict.get(source)
 
             if source_info:
+                media_id = source_info["value"]
+                if source_info.get("type") == "favorite_item_id" and not media_id.startswith("FV:"):
+                    media_id = f"FV:{media_id}"
+
                 hass.services.call('media_player', 'play_media', {
                     'entity_id': primary_speaker_entity_id,
-                    'media_content_id': source_info["value"],
+                    'media_content_id': media_id,
                     'media_content_type': source_info["type"]
                 })
 


### PR DESCRIPTION
## Summary
- keep track of media system toggle default
- set default media system state on startup
- prefix favorites in ags_select_source
- trigger playback whenever system turns on or TV turns off
- run grouping logic when selecting a new source

## Testing
- `python -m py_compile custom_components/ags_service/media_player.py custom_components/ags_service/ags_service.py custom_components/ags_service/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6858b0829a688330a7511e5635b5c9ed