### PR TITLE
Improve grouped test notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,151 @@ AGS Service Status: This sensor provides the overall status of the AGS service. 
 
 AGS Service Primary Speaker: This sensor checks each active room to determine the primary speaker. The primary speaker is the speaker with the highest priority (lowest numerical value) in the room.
 
-AGS Service Preferred Primary Speaker: This sensor is similar to the Primary Speaker sensor, but it allows for a preferred primary speaker to be
+AGS Service Preferred Primary Speaker: This sensor is similar to the Primary Speaker sensor, but it allows for a preferred primary speaker to be selected based on device priority.
+
+## Testing
+
+Unit tests for this integration are located in `tests/test_ags_service.py`. The
+suite verifies the following helper functions and behaviors:
+
+- `get_configured_rooms`
+- `get_active_rooms`
+- `update_ags_status`
+- `check_primary_speaker_logic`
+- `determine_primary_speaker`
+- `update_speaker_states`
+- `get_preferred_primary_speaker`
+- `get_inactive_tv_speakers`
+- `execute_ags_logic`
+- `ags_select_source`
+
+The individual test cases are grouped by the type of behavior they validate:
+
+**Configuration**
+- `test_get_configured_rooms` – verifies configured rooms are stored in
+  `hass.data`.
+- `test_get_active_rooms` – ensures room switches determine the active room
+  list.
+- `test_update_ags_status_disable_zone_true` – setting `disable_zone` prevents
+  `zone.home` from forcing the service off.
+- `test_default_on_behavior` – the service starts `ON` only when
+  `default_on` is `True`.
+- `test_default_source_used_when_blank` – the first configured source is used
+  when no selection exists.
+- `test_disable_tv_sources_behavior` – TV sources are excluded when
+  `disable_Tv_Source` is enabled.
+- `test_update_ags_status_override_when_off` – override content forces the
+  status to `Override` even if the system switch is off.
+- `test_async_setup_creates_sensors` – sensors load when `create_sensors` is
+  `True`.
+- `test_async_setup_skips_sensors` – sensors are skipped when the option is
+  `False`.
+
+**Status and Overrides**
+- `test_update_ags_status_zone_off` – sets `zone.home` to `0` and expects the
+  system status to become `OFF`.
+- `test_update_ags_status_override` – status becomes `Override` when a device
+  plays matching content.
+- `test_update_ags_status_tv_mode` – a TV playing in an active room sets the
+  status to `ON TV`.
+
+**Primary Speaker Logic**
+- `test_check_primary_speaker_logic_override` – override content chooses that
+  speaker as primary.
+- `test_determine_primary_speaker` – exercises the delayed recheck logic.
+- `test_determine_primary_speaker_priority_order` – the lowest priority number
+  speaker is selected when multiple are active.
+- `test_determine_primary_speaker_delay_default` – confirms the default
+  `primary_delay` of five seconds is used.
+- `test_determine_primary_speaker_delay_custom` – verifies a custom
+  `primary_delay` value is honored.
+- `test_get_preferred_primary_speaker` – selects the highest priority active
+  speaker.
+
+**Speaker States**
+- `test_update_speaker_states_on` – updates active speakers when AGS is `ON`.
+- `test_update_speaker_states_off` – all speakers are inactive when AGS is
+  `OFF`.
+- `test_get_inactive_tv_speakers` – detects TVs in inactive rooms.
+
+**Sources and HomeKit**
+- `test_execute_ags_logic_calls_services` – speaker join actions trigger a
+  service call.
+- `test_ags_select_source_tv` – selecting the `TV` source issues the correct
+  service request.
+- `test_homekit_player_creation_and_sync` – creates the HomeKit media player
+  when configured and keeps it in sync with the primary player.
+- `test_homekit_player_absent` – no HomeKit player entity is created when the
+  option is omitted.
+
+Run the tests from the repository root with:
+
+```bash
+pytest -q
+```
+
+### Triggering Tests from Home Assistant
+
+The service `ags_service.run_tests` executes the same test suite directly on your Home Assistant instance. Create a script that calls this service and expose it as a button to run the tests from the UI:
+
+```yaml
+script:
+  ags_run_tests:
+    sequence:
+      - service: ags_service.run_tests
+      # Optional: read the result out loud using TTS
+      - delay: '00:00:01'
+      - service: tts.google_translate_say
+        data:
+          entity_id: media_player.your_speaker
+          message: >-
+            {{ state_attr('persistent_notification.ags_service_tests', 'message') }}
+```
+
+Invoking the script runs the tests and posts a persistent notification with ID
+`ags_service_tests`. The message begins with an overall summary line and then
+lists each test result. A green check mark (✅) indicates success while a red X
+(❌) indicates failure. After every icon is a brief explanation describing what
+behavior the test verifies so you can see exactly why each case is included.
+You can view the result from the Notifications panel (bell icon) or, as shown
+above, have a TTS service announce the outcome.
+
+Example output:
+
+```
+✅ AGS Service Tests Passed
+Configuration:
+  ✅ verifies configured rooms are stored in hass.data
+  ✅ ensures room switches determine active rooms
+  ✅ disable_zone=True ignores zone.home
+  ✅ service starts ON only if default_on
+  ✅ first source used when none selected
+  ✅ TV sources skipped when disabled
+  ✅ override works even when service off
+  ✅ sensors created when enabled
+  ✅ sensors skipped when disabled
+
+Status and Overrides:
+  ✅ zone.home=0 forces the system OFF
+  ✅ override playback sets status
+  ✅ TV playing sets status to ON TV
+
+Primary Speaker Logic:
+  ✅ override content selects that speaker as primary
+  ✅ delayed recheck sets the primary speaker
+  ✅ primary speaker follows priority order
+  ✅ uses default primary_delay of 5s
+  ✅ uses custom primary_delay value
+  ✅ highest priority active speaker chosen
+
+Speaker States:
+  ✅ updates active speakers when AGS is ON
+  ✅ all speakers inactive when AGS OFF
+  ✅ detects TVs in inactive rooms
+
+Sources and HomeKit:
+  ✅ join service called for speaker groups
+  ✅ selecting TV source issues service request
+  ✅ HomeKit player created and synced
+  ✅ no HomeKit player when not configured
+```

--- a/tests/test_ags_service.py
+++ b/tests/test_ags_service.py
@@ -1,0 +1,592 @@
+import os
+import sys
+import importlib.util
+import asyncio
+import types
+import pytest
+
+class DummyVol:
+    def __getattr__(self, name):
+        def identity(v, *a, **k):
+            return v
+        return identity
+
+sys.modules.setdefault('voluptuous', DummyVol())
+
+# Provide minimal stubs for Home Assistant modules required by the media_player
+class DummyRestoreEntity:
+    pass
+
+
+class DummyMediaPlayerEntity:
+    pass
+
+
+sys.modules.setdefault(
+    'homeassistant.helpers.restore_state',
+    types.SimpleNamespace(RestoreEntity=DummyRestoreEntity),
+)
+sys.modules.setdefault(
+    'homeassistant.components.media_player',
+    types.SimpleNamespace(MediaPlayerEntity=DummyMediaPlayerEntity),
+)
+
+class DummyFeature:
+    SEEK = PLAY = PAUSE = STOP = SHUFFLE_SET = REPEAT_SET = NEXT_TRACK = (
+        PREVIOUS_TRACK
+    ) = SELECT_SOURCE = VOLUME_SET = TURN_ON = TURN_OFF = 1
+
+sys.modules.setdefault(
+    'homeassistant.components.media_player.const',
+    types.SimpleNamespace(MediaPlayerEntityFeature=DummyFeature),
+)
+sys.modules.setdefault(
+    'homeassistant.const',
+    types.SimpleNamespace(
+        STATE_IDLE='idle',
+        STATE_PLAYING='playing',
+        STATE_PAUSED='paused',
+        CONF_DEVICES='devices'
+    ),
+)
+sys.modules.setdefault(
+    'homeassistant.helpers.event',
+    types.SimpleNamespace(async_track_state_change_event=lambda *a, **k: None),
+)
+sys.modules.setdefault(
+    'homeassistant.helpers.config_validation',
+    types.SimpleNamespace(
+        Schema=lambda v: v,
+        ensure_list=lambda v: v,
+        string=lambda v=None: v,
+        boolean=lambda v=None: v,
+        positive_int=lambda v=None: v,
+    )
+)
+sys.modules.setdefault(
+    'homeassistant.helpers.discovery',
+    types.SimpleNamespace(async_load_platform=lambda *a, **k: None)
+)
+sys.modules.setdefault(
+    'homeassistant.helpers',
+    types.SimpleNamespace(
+        config_validation=sys.modules['homeassistant.helpers.config_validation'],
+        discovery=sys.modules['homeassistant.helpers.discovery'],
+        event=sys.modules['homeassistant.helpers.event'],
+    ),
+)
+
+# Load ags_service module directly without executing package __init__
+MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'custom_components', 'ags_service', 'ags_service.py')
+spec = importlib.util.spec_from_file_location('ags_service', MODULE_PATH)
+ags_service = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ags_service)
+
+# Expose ags_service under the package namespace so relative imports work
+pkg_name = 'custom_components.ags_service'
+package = types.ModuleType(pkg_name)
+package.__path__ = []
+sys.modules[pkg_name] = package
+sys.modules[pkg_name + '.ags_service'] = ags_service
+
+# Load the media_player module used for additional tests
+MP_MODULE_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'custom_components', 'ags_service', 'media_player.py'
+)
+mp_spec = importlib.util.spec_from_file_location(
+    'custom_components.ags_service.media_player', MP_MODULE_PATH
+)
+ags_media_player = importlib.util.module_from_spec(mp_spec)
+mp_spec.loader.exec_module(ags_media_player)
+
+# Load __init__ module for async_setup tests
+INIT_PATH = os.path.join(
+    os.path.dirname(__file__), '..', 'custom_components', 'ags_service', '__init__.py'
+)
+init_spec = importlib.util.spec_from_file_location('custom_components.ags_service.__init__', INIT_PATH)
+ags_init = importlib.util.module_from_spec(init_spec)
+init_spec.loader.exec_module(ags_init)
+
+
+class FakeState:
+    def __init__(self, state, **attributes):
+        self.state = state
+        self.attributes = attributes
+
+
+class FakeStates:
+    def __init__(self):
+        self._states = {}
+
+    def set(self, entity_id, state, **attrs):
+        self._states[entity_id] = FakeState(state, **attrs)
+
+    def get(self, entity_id, default=None):
+        return self._states.get(entity_id, default)
+
+
+class FakeServices:
+    def __init__(self):
+        self.calls = []
+
+    async def async_call(self, domain, service, data):
+        self.calls.append((domain, service, data))
+
+    def async_register(self, domain, service, func):
+        self.calls.append((domain, service, 'register'))
+
+
+class FakeLoop:
+    def call_soon_threadsafe(self, func, *args, **kwargs):
+        func(*args, **kwargs)
+
+
+class FakeHass:
+    def __init__(self):
+        self.data = {}
+        self.states = FakeStates()
+        self.loop = FakeLoop()
+        self.services = FakeServices()
+
+    def async_create_task(self, coro):
+        asyncio.get_event_loop().run_until_complete(coro)
+
+    async def async_add_executor_job(self, func, *args):
+        return func(*args)
+
+@pytest.fixture
+def basic_setup():
+    rooms = [
+        {
+            "room": "Living",
+            "devices": [
+                {"device_id": "media_player.living", "device_type": "speaker", "priority": 1},
+                {"device_id": "media_player.tv", "device_type": "tv", "priority": 2},
+            ],
+        }
+    ]
+    config = {
+        "rooms": rooms,
+        "Sources": [
+            {"Source": "Default", "Source_Value": "1", "media_content_type": "favorite_item_id", "source_default": True}
+        ],
+        "disable_zone": False,
+        "primary_delay": 1,
+        "homekit_player": None,
+        "create_sensors": False,
+        "default_on": True,
+        "static_name": None,
+        "disable_Tv_Source": False,
+    }
+    hass = FakeHass()
+    hass.data["ags_service"] = config
+    hass.states.set("zone.home", "1")
+    return config, hass
+
+
+def test_get_configured_rooms(basic_setup):
+    config, hass = basic_setup
+    rooms = config["rooms"]
+    result = ags_service.get_configured_rooms(rooms, hass)
+    assert result == ["Living"]
+    assert hass.data["configured_rooms"] == ["Living"]
+
+
+def test_get_active_rooms(basic_setup):
+    config, hass = basic_setup
+    rooms = config["rooms"]
+    hass.data["switch.living_media"] = True
+    result = ags_service.get_active_rooms(rooms, hass)
+    assert result == ["Living"]
+    assert hass.data["active_rooms"] == ["Living"]
+
+
+def test_update_ags_status_zone_off(basic_setup):
+    config, hass = basic_setup
+    hass.states.set("zone.home", "0")
+    result = ags_service.update_ags_status(config, hass)
+    assert result == "OFF"
+    assert hass.data["ags_status"] == "OFF"
+
+
+def test_update_ags_status_override(basic_setup):
+    config, hass = basic_setup
+    hass.states.set("media_player.living", "playing", media_content_id="fav")
+    config["rooms"][0]["devices"][0]["override_content"] = "fav"
+    result = ags_service.update_ags_status(config, hass)
+    assert result == "Override"
+    assert hass.data["ags_status"] == "Override"
+
+
+def test_update_ags_status_tv_mode(basic_setup):
+    config, hass = basic_setup
+    hass.data["active_rooms"] = ["Living"]
+    hass.data["switch_media_system_state"] = True
+    hass.states.set("media_player.tv", "on")
+    result = ags_service.update_ags_status(config, hass)
+    assert result == "ON TV"
+    assert hass.data["ags_status"] == "ON TV"
+
+
+def test_check_primary_speaker_logic_override(basic_setup):
+    config, hass = basic_setup
+    hass.data["ags_status"] = "Override"
+    hass.states.set("media_player.living", "playing", media_content_id="fav")
+    config["rooms"][0]["devices"][0]["override_content"] = "fav"
+    result = ags_service.check_primary_speaker_logic(config, hass)
+    assert result == "media_player.living"
+
+
+def test_determine_primary_speaker(basic_setup):
+    config, hass = basic_setup
+    hass.data["ags_status"] = "ON"
+    hass.data["active_rooms"] = ["Living"]
+    hass.states.set("media_player.living", "playing", group_members=["media_player.living"])
+    result = ags_service.determine_primary_speaker(config, hass)
+    assert result == "media_player.living"
+    assert hass.data["primary_speaker"] == "media_player.living"
+
+
+def test_determine_primary_speaker_priority_order():
+    rooms = [{
+        "room": "Living",
+        "devices": [
+            {"device_id": "media_player.first", "device_type": "speaker", "priority": 1},
+            {"device_id": "media_player.second", "device_type": "speaker", "priority": 2},
+        ],
+    }]
+    config = {
+        "rooms": rooms,
+        "Sources": [{"Source": "Default", "Source_Value": "1", "media_content_type": "favorite_item_id", "source_default": True}],
+        "disable_zone": False,
+        "primary_delay": 1,
+        "homekit_player": None,
+        "create_sensors": False,
+        "default_on": True,
+        "static_name": None,
+        "disable_Tv_Source": False,
+    }
+    hass = FakeHass()
+    hass.data["ags_service"] = config
+    hass.states.set("zone.home", "1")
+    hass.data["ags_status"] = "ON"
+    hass.data["active_rooms"] = ["Living"]
+    hass.states.set("media_player.first", "playing", group_members=["media_player.first"])
+    hass.states.set("media_player.second", "playing", group_members=["media_player.second"])
+    result = ags_service.determine_primary_speaker(config, hass)
+    assert result == "media_player.first"
+
+
+def test_update_speaker_states_on(basic_setup):
+    config, hass = basic_setup
+    hass.data["ags_status"] = "ON"
+    hass.data["active_rooms"] = ["Living"]
+    hass.states.set("media_player.living", "on")
+    active, inactive = ags_service.update_speaker_states(config["rooms"], hass)
+    assert active == ["media_player.living"]
+    assert inactive == []
+
+
+def test_get_preferred_primary_speaker(basic_setup):
+    config, hass = basic_setup
+    hass.data["active_speakers"] = ["media_player.living"]
+    result = ags_service.get_preferred_primary_speaker(config["rooms"], hass)
+    assert result == "media_player.living"
+
+
+def test_get_inactive_tv_speakers(basic_setup):
+    config, hass = basic_setup
+    hass.data["ags_status"] = "ON"
+    hass.data["active_rooms"] = ["Living"]
+    result = ags_service.get_inactive_tv_speakers(config["rooms"], hass)
+    assert result == []
+
+
+def test_execute_ags_logic_calls_services(basic_setup):
+    config, hass = basic_setup
+    hass.data.update({
+        "active_speakers": ["media_player.living"],
+        "ags_status": "ON",
+        "inactive_speakers": [],
+        "primary_speaker": "media_player.living",
+        "ags_inactive_tv_speakers": []
+    })
+    ags_service.execute_ags_logic(hass)
+    assert ("media_player", "join", {"entity_id": "media_player.living", "group_members": ["media_player.living"]}) in hass.services.calls
+
+
+def test_ags_select_source_tv(basic_setup):
+    config, hass = basic_setup
+    hass.data.update({
+        "ags_media_player_source": "TV",
+        "ags_status": "ON",
+        "primary_speaker": "media_player.living"
+    })
+    ags_service.ags_select_source(config, hass)
+    assert hass.services.calls[0][1] == "select_source"
+
+
+def test_determine_primary_speaker_delay_default(monkeypatch):
+    rooms = [
+        {"room": "Living", "devices": [{"device_id": "media_player.living", "device_type": "speaker", "priority": 1}]}
+    ]
+    config = {
+        "rooms": rooms,
+        "Sources": [{"Source": "Default", "Source_Value": "1", "media_content_type": "favorite_item_id", "source_default": True}],
+        "disable_zone": False,
+        "primary_delay": 5,
+        "homekit_player": None,
+        "create_sensors": False,
+        "default_on": True,
+        "static_name": None,
+        "disable_Tv_Source": False,
+    }
+    hass = FakeHass()
+    hass.data["ags_service"] = config
+    hass.data["ags_status"] = "ON"
+    hass.data["active_rooms"] = ["Living"]
+    hass.states.set("media_player.living", "paused", group_members=["media_player.living"])
+
+    delays = []
+
+    async def fake_sleep(sec):
+        delays.append(sec)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    ags_service.determine_primary_speaker(config, hass)
+    assert delays == [5]
+
+
+def test_determine_primary_speaker_delay_custom(monkeypatch):
+    rooms = [
+        {"room": "Living", "devices": [{"device_id": "media_player.living", "device_type": "speaker", "priority": 1}]}
+    ]
+    config = {
+        "rooms": rooms,
+        "Sources": [{"Source": "Default", "Source_Value": "1", "media_content_type": "favorite_item_id", "source_default": True}],
+        "disable_zone": False,
+        "primary_delay": 2,
+        "homekit_player": None,
+        "create_sensors": False,
+        "default_on": True,
+        "static_name": None,
+        "disable_Tv_Source": False,
+    }
+    hass = FakeHass()
+    hass.data["ags_service"] = config
+    hass.data["ags_status"] = "ON"
+    hass.data["active_rooms"] = ["Living"]
+    hass.states.set("media_player.living", "paused", group_members=["media_player.living"])
+
+    delays = []
+
+    async def fake_sleep(sec):
+        delays.append(sec)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    ags_service.determine_primary_speaker(config, hass)
+    assert delays == [2]
+
+
+def test_update_ags_status_disable_zone_true(basic_setup):
+    config, hass = basic_setup
+    config["disable_zone"] = True
+    hass.states.set("zone.home", "0")
+    result = ags_service.update_ags_status(config, hass)
+    assert result != "OFF"
+
+
+def test_update_speaker_states_off(basic_setup):
+    config, hass = basic_setup
+    hass.data["ags_status"] = "OFF"
+    active, inactive = ags_service.update_speaker_states(config["rooms"], hass)
+    assert active == []
+    assert inactive == ["media_player.living"]
+
+
+def test_default_on_behavior(monkeypatch):
+    rooms = [{"room": "Living", "devices": []}]
+    config = {
+        "rooms": rooms,
+        "Sources": [],
+        "disable_zone": False,
+        "primary_delay": 1,
+        "homekit_player": None,
+        "create_sensors": False,
+        "default_on": False,
+        "static_name": None,
+        "disable_Tv_Source": False,
+    }
+    hass = FakeHass()
+    hass.data["ags_service"] = config
+    hass.states.set("zone.home", "1")
+    hass.data.pop("switch_media_system_state", None)
+    result = ags_service.update_ags_status(config, hass)
+    assert result == "OFF"
+    config["default_on"] = True
+    hass.data.pop("switch_media_system_state", None)
+    result = ags_service.update_ags_status(config, hass)
+    assert result == "ON"
+
+
+def test_default_source_used_when_blank(basic_setup, monkeypatch):
+    config, hass = basic_setup
+    hass.data.pop("ags_media_player_source", None)
+
+    monkeypatch.setattr(ags_media_player, "update_ags_sensors", lambda c, h: None)
+    player = ags_media_player.AGSPrimarySpeakerMediaPlayer(hass, config)
+    player.hass = hass
+    player.update()
+    assert player.ags_source == "1"
+
+
+def test_disable_tv_sources_behavior(monkeypatch):
+    rooms = [
+        {
+            "room": "Living",
+            "devices": [
+                {"device_id": "media_player.living", "device_type": "speaker", "priority": 1},
+                {"device_id": "media_player.tv", "device_type": "tv", "priority": 2},
+            ],
+        }
+    ]
+    config = {
+        "rooms": rooms,
+        "Sources": [
+            {"Source": "Default", "Source_Value": "1", "media_content_type": "favorite_item_id", "source_default": True}
+        ],
+        "disable_zone": False,
+        "primary_delay": 1,
+        "homekit_player": None,
+        "create_sensors": False,
+        "default_on": True,
+        "static_name": None,
+        "disable_Tv_Source": False,
+    }
+    hass = FakeHass()
+    hass.data["ags_service"] = config
+    hass.data["ags_status"] = "ON TV"
+    hass.data["primary_speaker"] = "media_player.living"
+    hass.states.set(
+        "media_player.tv",
+        "on",
+        source_list=["HDMI1", "HDMI2"],
+        source="HDMI1",
+        group_members=["media_player.tv"],
+    )
+
+    monkeypatch.setattr(ags_media_player, "update_ags_sensors", lambda c, h: None)
+    player = ags_media_player.AGSPrimarySpeakerMediaPlayer(hass, config)
+    player.hass = hass
+    player.update()
+    assert player.source_list == ["HDMI1", "HDMI2"]
+
+    config["disable_Tv_Source"] = True
+    hass.data["ags_service"] = config
+    player = ags_media_player.AGSPrimarySpeakerMediaPlayer(hass, config)
+    player.hass = hass
+    player.update()
+    assert "TV" in player.source_list
+
+
+def test_homekit_player_creation_and_sync(basic_setup, monkeypatch):
+    config, hass = basic_setup
+    config["homekit_player"] = "HK"
+    added = []
+
+    def add_entities(entities, update=False):
+        added.extend(entities)
+
+    monkeypatch.setattr(ags_media_player, "update_ags_sensors", lambda c, h: None)
+    asyncio.get_event_loop().run_until_complete(
+        ags_media_player.async_setup_platform(hass, {}, add_entities)
+    )
+
+    assert any(isinstance(e, ags_media_player.MediaSystemMediaPlayer) for e in added)
+
+    primary = next(e for e in added if isinstance(e, ags_media_player.AGSPrimarySpeakerMediaPlayer))
+    hk = next(e for e in added if isinstance(e, ags_media_player.MediaSystemMediaPlayer))
+    primary.hass = hass
+    hk.hass = hass
+    hass.data.update({"primary_speaker": "media_player.living", "ags_status": "ON"})
+    hass.states.set("media_player.living", "playing", group_members=["media_player.living"])
+    primary.update()
+    assert hk.state == primary.state
+
+
+def test_homekit_player_absent(basic_setup, monkeypatch):
+    config, hass = basic_setup
+    added = []
+
+    def add_entities(entities, update=False):
+        added.extend(entities)
+
+    monkeypatch.setattr(ags_media_player, "update_ags_sensors", lambda c, h: None)
+    asyncio.get_event_loop().run_until_complete(
+        ags_media_player.async_setup_platform(hass, {}, add_entities)
+    )
+
+    assert not any(isinstance(e, ags_media_player.MediaSystemMediaPlayer) for e in added)
+
+
+def test_update_ags_status_override_when_off(basic_setup):
+    config, hass = basic_setup
+    hass.data["switch_media_system_state"] = False
+    hass.states.set("media_player.living", "playing", media_content_id="fav")
+    config["rooms"][0]["devices"][0]["override_content"] = "fav"
+    result = ags_service.update_ags_status(config, hass)
+    assert result == "Override"
+
+
+def test_async_setup_creates_sensors(monkeypatch):
+    """Sensors load when create_sensors=True."""
+    config = {
+        ags_init.DOMAIN: {
+            "rooms": [],
+            "Sources": [],
+            "disable_zone": False,
+            "primary_delay": 1,
+            "homekit_player": None,
+            "create_sensors": True,
+            "default_on": False,
+            "static_name": None,
+            "disable_Tv_Source": False,
+        }
+    }
+    hass = FakeHass()
+    calls = []
+
+    async def fake_load(h, platform, domain, data, conf):
+        calls.append(platform)
+
+    monkeypatch.setattr(ags_init, "async_load_platform", fake_load)
+    asyncio.get_event_loop().run_until_complete(ags_init.async_setup(hass, config))
+    assert "sensor" in calls
+
+
+def test_async_setup_skips_sensors(monkeypatch):
+    """Sensors are skipped when create_sensors=False."""
+    config = {
+        ags_init.DOMAIN: {
+            "rooms": [],
+            "Sources": [],
+            "disable_zone": False,
+            "primary_delay": 1,
+            "homekit_player": None,
+            "create_sensors": False,
+            "default_on": False,
+            "static_name": None,
+            "disable_Tv_Source": False,
+        }
+    }
+    hass = FakeHass()
+    calls = []
+
+    async def fake_load(h, platform, domain, data, conf):
+        calls.append(platform)
+
+    monkeypatch.setattr(ags_init, "async_load_platform", fake_load)
+    asyncio.get_event_loop().run_until_complete(ags_init.async_setup(hass, config))
+    assert "sensor" not in calls


### PR DESCRIPTION
## Summary
- expand README test documentation and add grouped example output
- group pytest results by category in `run_internal_tests`
- add coverage for `create_sensors` logic
- better format notification results with indentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ba1628188330b95d9ceb0a5258f2