### PR TITLE
Fix song changes when primary speaker switches

### DIFF
--- a/AGS Automation Exmaple.yaml
+++ b/AGS Automation Exmaple.yaml
@@ -84,10 +84,10 @@ action:
     then:
       - service: media_player.join
         data:
-          entity_id: "{{ state_attr('media_player.ags_media_system', 'primary_speaker' )}}"
+          entity_id: "{{ state_attr('media_player.ags_media_system', 'primary_speaker' ) }}"
           group_members: >-
-            {{ state_attr('media_player.ags_media_system', 'active_speakers' )
-            }}
+            {{ state_attr('media_player.ags_media_system', 'active_speakers' ) }}
+      - delay: '00:00:02'
     else: null
     alias: Join Action
   - if:


### PR DESCRIPTION
## Summary
- keep previous primary speaker until re-check completes so playback isn't interrupted
- wait briefly between joining and removing speakers in automation

## Testing
- `python -m py_compile custom_components/ags_service/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685ad0744a848330a29c51817967f284