### PR TITLE
Add schedule entity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ ags_service:
   default_on: false
   static_name: "AGS Media Player"
   disable_Tv_Source: false
+  schedule_entity:
+    entity_id: schedule.my_music
+    on_state: "on"
+    off_state: "off"
   rooms:
     - room: "Room 1"
       devices:
@@ -108,7 +112,7 @@ ags_service:
 
 rooms: A list of rooms. Each room is an object that has a room name and a list of devices. Each device is an object that has a device_id, device_type, and priority.
 sources: The sources of audio that can be selected. Add ``source_default: true`` to mark the entry that should be used when no source has been chosen. If no entry is marked, the first source in the list will be used by default.
-homekit_player, create_sensors, default_on, static_name, disable_Tv_Source, and interval_sync are optional settings that provide extra capabilities.
+homekit_player, create_sensors, default_on, static_name, disable_Tv_Source, and interval_sync are optional settings that provide extra capabilities. The ``schedule_entity`` option allows AGS to follow a Home Assistant schedule (or any entity) by specifying ``entity_id`` along with optional ``on_state`` and ``off_state`` values.
 
 
 ##Automation

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -24,6 +24,7 @@ CONF_DEFAULT_ON = 'default_on'
 CONF_STATIC_NAME = 'static_name'
 CONF_DISABLE_TV_SOURCE = 'disable_Tv_Source'
 CONF_INTERVAL_SYNC = 'interval_sync'
+CONF_SCHEDULE_ENTITY = 'schedule_entity'
 CONF_SOURCES = 'Sources'
 CONF_SOURCE = 'Source'
 CONF_MEDIA_CONTENT_TYPE = 'media_content_type'
@@ -77,6 +78,11 @@ DEVICE_SCHEMA = vol.Schema({
     vol.Optional(CONF_STATIC_NAME, default=None): cv.string,
     vol.Optional(CONF_DISABLE_TV_SOURCE, default=False): cv.boolean,
     vol.Optional(CONF_INTERVAL_SYNC, default=30): cv.positive_int,
+    vol.Optional(CONF_SCHEDULE_ENTITY): vol.Schema({
+        vol.Required('entity_id'): cv.string,
+        vol.Optional('on_state', default='on'): cv.string,
+        vol.Optional('off_state', default='off'): cv.string,
+    }),
 })
 
 async def async_setup(hass, config):
@@ -93,8 +99,8 @@ async def async_setup(hass, config):
         'create_sensors': ags_config.get(CONF_CREATE_SENSORS, False),
         'default_on': ags_config.get(CONF_DEFAULT_ON, False),
         'static_name': ags_config.get(CONF_STATIC_NAME, None),
-
-        'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False)
+        'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
+        'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY)
    }
 
     # Load the sensor and switch platforms and pass the configuration to them

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -128,19 +128,35 @@ def update_ags_status(ags_config, hass):
 
     media_system_state = hass.data.get('switch_media_system_state')
     if media_system_state is None:
-        if  ags_config['default_on']: 
-            ags_status = "ON"
+        media_system_state = ags_config['default_on']
+        hass.data['media_system_state'] = media_system_state
+
+    # Determine schedule entity state if configured
+    schedule_cfg = hass.data['ags_service'].get('schedule_entity')
+    schedule_on = True
+    if schedule_cfg:
+        state_obj = hass.states.get(schedule_cfg['entity_id'])
+        if state_obj is not None:
+            if state_obj.state == schedule_cfg.get('on_state', 'on'):
+                schedule_on = True
+            elif state_obj.state == schedule_cfg.get('off_state', 'off'):
+                schedule_on = False
+            else:
+                schedule_on = False
         else:
+            schedule_on = False
+        hass.data['schedule_state'] = schedule_on
+
+    if schedule_cfg:
+        if media_system_state != schedule_on or not media_system_state:
             ags_status = "OFF"
-
-        hass.data['ags_status'] = ags_status
-        hass.data['media_system_state'] = ags_config['default_on']
-        return ags_status
-
-    if not media_system_state:
-        ags_status = "OFF"
-        hass.data['ags_status'] = ags_status
-        return ags_status
+            hass.data['ags_status'] = ags_status
+            return ags_status
+    else:
+        if not media_system_state:
+            ags_status = "OFF"
+            hass.data['ags_status'] = ags_status
+            return ags_status
 
     # Check for TV in active rooms
     for room in rooms:

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -30,6 +30,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     # Add switches for rooms and zone.home
     entities_to_track = ['zone.home']
+    schedule_cfg = ags_config.get('schedule_entity')
+    if schedule_cfg and schedule_cfg.get('entity_id'):
+        entities_to_track.append(schedule_cfg['entity_id'])
     for room in rooms:
         room_switch = f"switch.{room['room'].lower().replace(' ', '_')}_media"
         entities_to_track.append(room_switch)

--- a/custom_components/ags_service/sensor.py
+++ b/custom_components/ags_service/sensor.py
@@ -50,6 +50,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     hass.data['ags_sensors'] = sensors
 
     entities_to_track = ['zone.home']
+    schedule_cfg = ags_config.get('schedule_entity')
+    if schedule_cfg and schedule_cfg.get('entity_id'):
+        entities_to_track.append(schedule_cfg['entity_id'])
     
   
 


### PR DESCRIPTION
## Summary
- add optional `schedule_entity` config
- monitor schedule entity state in sensors and media player
- include schedule state in AGS status evaluation
- update docs with example usage

## Testing
- `python -m py_compile custom_components/ags_service/__init__.py custom_components/ags_service/ags_service.py custom_components/ags_service/media_player.py custom_components/ags_service/sensor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f75dd1ab88330a13244d9bc7471f3