### PR TITLE
Add OTT device support for TV

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ ags_service:
         - device_id: "media_player.device_1"
           device_type: "tv"
           priority: 1
+          ott_device: "media_player.ott_1"
         - device_id: "media_player.device_2"
           device_type: "speaker"
           priority: 2
@@ -111,7 +112,7 @@ ags_service:
 
 ```
 
-rooms: A list of rooms. Each room is an object that has a room name and a list of devices. Each device is an object that has a device_id, device_type, and priority.
+rooms: A list of rooms. Each room is an object that has a room name and a list of devices. Each device is an object that has a ``device_id``, ``device_type``, and ``priority``. For TV devices you may also specify ``ott_device`` which points to the media player entity used for picture and playback controls.
 sources: The sources of audio that can be selected. Add ``source_default: true`` to mark the entry that should be used when no source has been chosen. If no entry is marked, the first source in the list will be used by default.
 The schedule entry's ``on_state`` and ``off_state`` fields are optional and default to ``on`` and ``off`` if omitted.
 homekit_player, create_sensors, default_on, static_name, disable_Tv_Source, and interval_sync are optional settings that provide extra capabilities. The ``schedule_entity`` option allows AGS to follow a Home Assistant schedule (or any entity) by specifying ``entity_id`` along with optional ``on_state`` and ``off_state`` values (defaults are ``on`` and ``off``). ``schedule_override`` is also optional. When enabled, the media system turns off once whenever the schedule changes to its ``off`` state and can then be manually turned back on even if the schedule remains off. If Home Assistant restarts while the schedule is off, the system begins in the off state regardless of ``default_on``. When the schedule later returns to its ``on`` state, AGS automatically turns the media system back on via its internal switch, though you may still turn it off manually if desired.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ sources: The sources of audio that can be selected. Add ``source_default: true``
 The schedule entry's ``on_state`` and ``off_state`` fields are optional and default to ``on`` and ``off`` if omitted.
 homekit_player, create_sensors, default_on, static_name, disable_Tv_Source, and interval_sync are optional settings that provide extra capabilities. The ``schedule_entity`` option allows AGS to follow a Home Assistant schedule (or any entity) by specifying ``entity_id`` along with optional ``on_state`` and ``off_state`` values (defaults are ``on`` and ``off``). ``schedule_override`` is also optional. When enabled, the media system turns off once whenever the schedule changes to its ``off`` state and can then be manually turned back on even if the schedule remains off. If Home Assistant restarts while the schedule is off, the system begins in the off state regardless of ``default_on``. When the schedule later returns to its ``on`` state, AGS automatically turns the media system back on via its internal switch, though you may still turn it off manually if desired.
 
+HomeKit does not handle the AGS player's dynamically changing name and TV source list. If you plan to expose the player to HomeKit either specify ``homekit_player`` so a dedicated media player with a static name is created, or enable ``static_name`` and set ``disable_Tv_Source: true`` to keep the main player's name and source list constant.
+
 
 ##Automation
 

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -23,6 +23,7 @@ CONF_STATIC_NAME = 'static_name'
 CONF_DISABLE_TV_SOURCE = 'disable_Tv_Source'
 CONF_INTERVAL_SYNC = 'interval_sync'
 CONF_SCHEDULE_ENTITY = 'schedule_entity'
+CONF_OTT_DEVICE = 'ott_device'
 CONF_SOURCES = 'Sources'
 CONF_SOURCE = 'Source'
 CONF_MEDIA_CONTENT_TYPE = 'media_content_type'
@@ -47,6 +48,7 @@ DEVICE_SCHEMA = vol.Schema({
                                     vol.Required("device_type"): cv.string,
                                     vol.Required("priority"): cv.positive_int,
                                     vol.Optional("override_content"): cv.string,
+                                    vol.Optional(CONF_OTT_DEVICE): cv.string,
                                 }
                             )
                         ],
@@ -86,8 +88,16 @@ DEVICE_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the custom component."""
-    
+
     ags_config = config[DOMAIN]
+
+    # Validate ott_device usage
+    for room in ags_config['rooms']:
+        for device in room['devices']:
+            if CONF_OTT_DEVICE in device and device['device_type'] != 'tv':
+                raise vol.Invalid(
+                    "ott_device is only allowed for devices with device_type 'tv'"
+                )
 
     hass.data[DOMAIN] = {
         'rooms': ags_config['rooms'],

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -167,16 +167,19 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         if self.ags_status == "ON TV" and self.primary_speaker_room:
             selected_device_id = None
-            
+
             # Filter out speaker devices and sort remaining devices by priority
             sorted_devices = sorted(
                 [device for device in room["devices"] if device["device_type"] != "speaker"],
                 key=lambda x: x['priority']
             )
-            
-            # If there's a device in the sorted list, use its ID. Otherwise, default to primary speaker.
-            selected_device_id = sorted_devices[0]["device_id"] if sorted_devices else self.hass.data.get('primary_speaker', None)
-            
+
+            if sorted_devices:
+                first_device = sorted_devices[0]
+                selected_device_id = first_device.get('ott_device', first_device["device_id"])
+            else:
+                selected_device_id = self.hass.data.get('primary_speaker', None)
+
             self.primary_speaker_entity_id = selected_device_id
         else:
             self.primary_speaker_entity_id = self.hass.data.get('primary_speaker', None)


### PR DESCRIPTION
## Summary
- add `ott_device` configuration option for TV devices
- validate that the option is only used with device_type `tv`
- use OTT device for picture and control when TV is active
- document OTT device usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68601ea18da083308fbf6fe381cccc38