### PR TITLE
Ensure only TV source or media stop

### DIFF
--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -127,7 +127,8 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         await enqueue_media_action(self.hass, "unjoin", {"entity_id": members})
 
         has_tv = any(d.get("device_type") == "tv" for d in self.room.get("devices", []))
-        if has_tv and not self.hass.data["ags_service"].get("disable_Tv_Source"):
+        use_tv_source = has_tv and not self.hass.data["ags_service"].get("disable_Tv_Source")
+        if use_tv_source:
             await enqueue_media_action(self.hass, "delay", {"seconds": 1})
             for member in members:
                 await enqueue_media_action(
@@ -138,7 +139,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
 
         rooms = self.hass.data["ags_service"]["rooms"]
         active_rooms = get_active_rooms(rooms, self.hass)
-        if not active_rooms:
+        if not active_rooms and not use_tv_source:
             await enqueue_media_action(self.hass, "media_stop", {"entity_id": members})
 
 class AGSActionsSwitch(SwitchEntity, RestoreEntity):


### PR DESCRIPTION
## Summary
- update room switch unjoin logic to avoid calling both `select_source` and `media_stop`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861d3fbc91c83308d41af2069f99eef