### PR TITLE
Remove delay and conditional stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 - Delay the source change slightly so the unjoin completes without errors
 - Final-room shutdown still uses `media_stop`
 
+### v1.3.7
+- Removed the one second delay before resetting TV speakers
+- Skip `media_stop` when the last active room has a TV
+
 ### v1.3.5
 - Removed the pre-action sensor refresh for join/unjoin
 

--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -132,7 +132,6 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
 
         has_tv = any(d.get("device_type") == "tv" for d in self.room.get("devices", []))
         if has_tv and not self.hass.data["ags_service"].get("disable_Tv_Source"):
-            await enqueue_media_action(self.hass, "delay", {"seconds": 1})
             for member in members:
                 await enqueue_media_action(
                     self.hass,
@@ -142,7 +141,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
 
         rooms = self.hass.data["ags_service"]["rooms"]
         active_rooms = get_active_rooms(rooms, self.hass)
-        if not active_rooms:
+        if not active_rooms and not has_tv:
             await enqueue_media_action(self.hass, "media_stop", {"entity_id": members})
 
 class AGSActionsSwitch(SwitchEntity, RestoreEntity):


### PR DESCRIPTION
## Summary
- remove the unjoin delay when resetting TVs to their input
- don't send `media_stop` after the last room turns off if that room has a TV
- document the changes in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6861de93fb4c8330b48911ab890917f7