### PR TITLE
Adjust status change triggers

### DIFF
--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -117,8 +117,11 @@ async def async_setup(hass, config):
     await ensure_action_queue(hass)
 
     async def _clear_startup(_event):
-        await asyncio.sleep(5)
-        hass.data[DOMAIN]['startup_pending'] = False
+        async def _delayed_clear():
+            await asyncio.sleep(5)
+            hass.data[DOMAIN]['startup_pending'] = False
+
+        hass.async_create_task(_delayed_clear())
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _clear_startup)
 

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -1,7 +1,5 @@
 """Main module for the AGS Service integration."""
 import voluptuous as vol
-import asyncio
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -110,20 +108,11 @@ async def async_setup(hass, config):
         'static_name': ags_config.get(CONF_STATIC_NAME, None),
         'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
         'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY),
-        'startup_pending': True,
     }
 
     # Initialize shared media action queue
     await ensure_action_queue(hass)
 
-    async def _clear_startup(_event):
-        async def _delayed_clear():
-            await asyncio.sleep(5)
-            hass.data[DOMAIN]['startup_pending'] = False
-
-        hass.async_create_task(_delayed_clear())
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _clear_startup)
 
     # Load the sensor and switch platforms and pass the configuration to them
     create_sensors = ags_config.get('create_sensors', False)

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -687,10 +687,9 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
         elif new_status in ("ON", "ON TV"):
             results = await speaker_status_check(hass)
 
-            preferred_primary = (
-                hass.data.get("primary_speaker")
-                or hass.data.get("preferred_primary_speaker")
-            )
+            preferred_primary = hass.data.get("primary_speaker")
+            if not preferred_primary or preferred_primary == "none":
+                preferred_primary = hass.data.get("preferred_primary_speaker")
 
             message_parts = [
                 (
@@ -718,7 +717,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
                 message_parts.append("no extra speakers")
 
             if not preferred_primary or preferred_primary == "none":
-                message_parts.append("skipped source selection - no primary speaker")
+                message_parts.append("skipped source selection - no primary or preferred speaker")
                 await send_notification(
                     hass,
                     f"AGS {new_status}",

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -649,8 +649,15 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
         # calculation has not finished which leads to skipped source selection.
         # Wait for the sensor update routine to complete before proceeding so
         # we operate on the final values.
+        while AGS_SENSOR_RUNNING:
+            await asyncio.sleep(0.1)
+
         attempts = 0
-        while AGS_SENSOR_RUNNING and attempts < 50:
+        while (
+            hass.data.get("primary_speaker") in (None, "none")
+            and hass.data.get("preferred_primary_speaker") in (None, "none")
+            and attempts < 20
+        ):
             await asyncio.sleep(0.1)
             attempts += 1
 
@@ -672,7 +679,6 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
 
             if all_speakers:
                 await enqueue_media_action(hass, "unjoin", {"entity_id": all_speakers})
-                await enqueue_media_action(hass, "delay", {"seconds": 0.5})
 
             for room in rooms:
                 members = [

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -661,11 +661,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
     up‑to‑date information.
     """
     try:
-        # Ensure Home Assistant startup delay and an initial sensor update have
-        # completed before running any actions
-        while hass.data['ags_service'].get('startup_pending', False):
-            await asyncio.sleep(0.1)
-
+        # Wait for the initial sensor update to complete before running any actions
         while not hass.data.get('ags_first_update_done'):
             await asyncio.sleep(0.1)
 
@@ -769,7 +765,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
                 await send_notification(
                     hass,
                     f"AGS {new_status}",
-                    "; ".join(message_parts),
+                    "\n".join(message_parts),
                 )
                 return
 
@@ -791,7 +787,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
             await send_notification(
                 hass,
                 f"AGS {new_status}",
-                "; ".join(message_parts),
+                "\n".join(message_parts),
             )
     except Exception as exc:  # pragma: no cover - safety net
         _LOGGER.warning("Error handling AGS status change: %s", exc)

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -643,6 +643,17 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
     synchronized and the appropriate source is selected for playback.
     """
     try:
+        # The status change can be triggered while the sensors are still
+        # updating.  When that happens ``primary_speaker`` or
+        # ``preferred_primary_speaker`` may still be ``"none"`` because the
+        # calculation has not finished which leads to skipped source selection.
+        # Wait for the sensor update routine to complete before proceeding so
+        # we operate on the final values.
+        attempts = 0
+        while AGS_SENSOR_RUNNING and attempts < 50:
+            await asyncio.sleep(0.1)
+            attempts += 1
+
         rooms = ags_config["rooms"]
         actions_enabled = hass.data.get("switch.ags_actions", True)
 

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -600,7 +600,11 @@ async def speaker_status_check(hass) -> None:
 
 
 async def handle_ags_status_change(hass, ags_config, new_status, old_status):
-    """Execute speaker actions when AGS status changes."""
+    """React to AGS status updates.
+
+    When the status becomes ``ON`` or ``ON TV`` the active speakers are
+    synchronized and the appropriate source is selected for playback.
+    """
     try:
         rooms = ags_config["rooms"]
         actions_enabled = hass.data.get("switch.ags_actions", True)

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -64,9 +64,9 @@ def update_ags_sensors(ags_config, hass):
         get_active_rooms(rooms, hass)
         prev_status = hass.data.get('ags_status')
         update_ags_status(ags_config, hass)
+        update_speaker_states(rooms, hass)
         get_preferred_primary_speaker(rooms, hass)
         determine_primary_speaker(ags_config, hass)
-        update_speaker_states(rooms, hass)
         get_inactive_tv_speakers(rooms, hass)
         new_status = hass.data.get('ags_status')
         if new_status != prev_status:


### PR DESCRIPTION
## Summary
- handle AGS status changes when turning **to** ON/ON TV instead of only from OFF
- ensure there is a valid primary speaker before selecting sources

## Testing
- `python -m py_compile $(find custom_components -name "*.py" -print)`

------
https://chatgpt.com/codex/tasks/task_e_686334e115648330b38a9c2e14d78b28