### PR TITLE
Add Sonos favorites source loader and media browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ HomeKit does not handle the AGS player's dynamically changing name and TV source
 ### Auto-fill sources from Sonos
 
 On startup the integration automatically loads Sonos favorites into the
-``Sources`` list. You can also run the ``ags_service.load_sonos_favorites``
-service at any time to refresh the list. Sources defined in the configuration
-are kept and any new favorites are added to the end.
+``Sources`` list—no extra configuration is needed. You can run the
+``ags_service.load_sonos_favorites`` service at any time to refresh the list.
+Any sources defined in ``configuration.yaml`` remain intact and any new
+favorites are appended to the end.
 
 ```
 service: ags_service.load_sonos_favorites

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The integration continuously tracks room occupancy and speaker states, regroupin
 * `AGS Service Preferred Primary Speaker` – backup speaker that will take over if the primary stops playing.
 * `AGS Service Source` – name of the media source that will be played when AGS starts playback.
 * `AGS Service Inactive TV Speakers` – TV‑related speakers that are currently inactive.
+* `AGS Service Sonos Favorites` – titles of favorites retrieved from Sonos.
 
 All of the data from these sensors is also available as attributes of the
 `media_player.ags_media_player` entity, so you may disable the sensors and still
@@ -239,12 +240,16 @@ Each sensor uses specific logic to report the state of the system:
 * **AGS Service Preferred Primary Speaker** – next speaker AGS will use if the primary stops.
 * **AGS Service Source** – numeric media source value for the selected item.
 * **AGS Service Inactive TV Speakers** – speakers attached to TVs that are currently inactive.
+* **AGS Service Sonos Favorites** – list of favorite titles loaded from Sonos.
 
 ## License
 
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.
 
 # Changelog
+
+### v1.4.3
+- New sensor ``AGS Service Sonos Favorites`` exposes the titles loaded from Sonos.
 
 ### v1.4.2
 - Sonos favorites now load from the highest priority speaker when no ``entity_id`` is provided.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ data:
 
 If no ``entity_id`` is provided the first configured speaker is used.
 
+Whenever you select an item from the media browser or the player's source list,
+the ``AGS Service Source`` sensor updates to reflect the chosen favorite.
+
 
 ## Automation
 
@@ -237,6 +240,9 @@ Each sensor uses specific logic to report the state of the system:
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.
 
 # Changelog
+
+### v1.4.1
+- ``AGS Service Source`` updates when you play a favorite via the media browser.
 
 ### v1.4.0
 - Sources are automatically populated from Sonos favorites at startup.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ data:
   entity_id: media_player.living_room  # optional
 ```
 
-If no ``entity_id`` is provided the first configured speaker is used.
+If no ``entity_id`` is provided the highest priority speaker is used.
 
 Whenever you select an item from the media browser or the player's source list,
 the ``AGS Service Source`` sensor updates to reflect the chosen favorite.
@@ -241,6 +241,9 @@ Each sensor uses specific logic to report the state of the system:
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.
 
 # Changelog
+
+### v1.4.2
+- Sonos favorites now load from the highest priority speaker when no ``entity_id`` is provided.
 
 ### v1.4.1
 - ``AGS Service Source`` updates when you play a favorite via the media browser.

--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ HomeKit does not handle the AGS player's dynamically changing name and TV source
 
 ### Auto-fill sources from Sonos
 
-Run the ``ags_service.load_sonos_favorites`` service to automatically append
-Sonos favorites to the ``Sources`` list. Sources defined in the configuration
+On startup the integration automatically loads Sonos favorites into the
+``Sources`` list. You can also run the ``ags_service.load_sonos_favorites``
+service at any time to refresh the list. Sources defined in the configuration
 are kept and any new favorites are added to the end.
 
 ```
@@ -238,8 +239,8 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 # Changelog
 
 ### v1.4.0
-- New service ``load_sonos_favorites`` to populate sources from Sonos
-  favorites.
+- Sources are automatically populated from Sonos favorites at startup.
+- New service ``load_sonos_favorites`` lets you refresh the list on demand.
 - AGS media player now supports the Home Assistant media browser.
 
 ### v1.3.0

--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 
 # Changelog
 
+### v1.4.4
+- Delay loading Sonos favorites until Home Assistant is fully started to ensure speakers are ready.
+- New sensor ``AGS Service Sonos Favorites`` now populates once favorites are available.
+
 ### v1.4.3
 - New sensor ``AGS Service Sonos Favorites`` exposes the titles loaded from Sonos.
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 - Delay loading Sonos favorites until Home Assistant is fully started to ensure speakers are ready.
 - New sensor ``AGS Service Sonos Favorites`` now populates once favorites are available.
 
+### v1.4.5
+- Retry loading favorites if the first attempt fails so the Sources list eventually populates
+
 ### v1.4.3
 - New sensor ``AGS Service Sonos Favorites`` exposes the titles loaded from Sonos.
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,20 @@ ags_service:
 
 HomeKit does not handle the AGS player's dynamically changing name and TV source list. If you plan to expose the player to HomeKit either specify ``homekit_player`` so a dedicated media player with a static name is created, or enable ``static_name`` and set ``disable_Tv_Source: true`` to keep the main player's name and source list constant.
 
+### Auto-fill sources from Sonos
+
+Run the ``ags_service.load_sonos_favorites`` service to automatically append
+Sonos favorites to the ``Sources`` list. Sources defined in the configuration
+are kept and any new favorites are added to the end.
+
+```
+service: ags_service.load_sonos_favorites
+data:
+  entity_id: media_player.living_room  # optional
+```
+
+If no ``entity_id`` is provided the first configured speaker is used.
+
 
 ## Automation
 
@@ -222,6 +236,11 @@ Each sensor uses specific logic to report the state of the system:
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.
 
 # Changelog
+
+### v1.4.0
+- New service ``load_sonos_favorites`` to populate sources from Sonos
+  favorites.
+- AGS media player now supports the Home Assistant media browser.
 
 ### v1.3.0
 - Added schedule entity support and auto-start when the schedule turns on

--- a/README.md
+++ b/README.md
@@ -181,10 +181,14 @@ HomeKit does not handle the AGS player's dynamically changing name and TV source
 ### Auto-fill sources from Sonos
 
 On startup the integration automatically loads Sonos favorites into the
-``Sources`` list—no extra configuration is needed. You can run the
-``ags_service.load_sonos_favorites`` service at any time to refresh the list.
-Any sources defined in ``configuration.yaml`` remain intact and any new
-favorites are appended to the end.
+``Sources`` list—no extra configuration is needed. The favorites are gathered
+by calling the Sonos player's ``media_player.browse_media`` service and reading
+the ``Favorites`` directory. Each favorite's title becomes the ``Source`` name
+while its ``media_content_id`` and ``media_content_type`` populate the
+``Source_Value`` and ``media_content_type`` fields. Duplicate titles are skipped
+so any manually defined sources remain intact. You can run the
+``ags_service.load_sonos_favorites`` service at any time to refresh the list and
+append any new favorites that Sonos reports.
 
 ```
 service: ags_service.load_sonos_favorites

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -101,7 +101,7 @@ async def async_setup(hass, config):
 
     hass.data[DOMAIN] = {
         'rooms': ags_config['rooms'],
-        'Sources': ags_config['Sources'], 
+        'Sources': ags_config['Sources'],
         'disable_zone': ags_config.get(CONF_DISABLE_ZONE, False),
         'primary_delay': ags_config.get(CONF_PRIMARY_DELAY, 5),  # Delay before retrying speaker detection
         'homekit_player': ags_config.get(CONF_HOMEKIT_PLAYER, None),
@@ -111,6 +111,13 @@ async def async_setup(hass, config):
         'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
         'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY)
    }
+
+    async def _service_load_favorites(call):
+        entity = call.data.get('entity_id')
+        from .ags_service import async_update_sources_from_sonos
+        await async_update_sources_from_sonos(hass, entity)
+
+    hass.services.async_register(DOMAIN, 'load_sonos_favorites', _service_load_favorites)
 
     # Load the sensor and switch platforms and pass the configuration to them
     create_sensors = ags_config.get('create_sensors', False)

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -128,7 +128,11 @@ async def async_setup(hass, config):
     async def _delayed_load(_: object) -> None:
         # Wait briefly so Sonos speakers are fully initialized
         await asyncio.sleep(10)
-        await async_update_sources_from_sonos(hass)
+        success = await async_update_sources_from_sonos(hass)
+        if not success:
+            # Retry once more in case the speakers were still starting up
+            await asyncio.sleep(20)
+            await async_update_sources_from_sonos(hass)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _delayed_load)
 

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -1,5 +1,6 @@
 """Main module for the AGS Service integration."""
 import voluptuous as vol
+import asyncio
 
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -125,6 +126,8 @@ async def async_setup(hass, config):
     from homeassistant.core import EVENT_HOMEASSISTANT_STARTED
 
     async def _delayed_load(_: object) -> None:
+        # Wait briefly so Sonos speakers are fully initialized
+        await asyncio.sleep(10)
         await async_update_sources_from_sonos(hass)
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _delayed_load)

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -121,7 +121,12 @@ async def async_setup(hass, config):
 
     # Populate sources list from Sonos favorites on startup
     from .ags_service import async_update_sources_from_sonos
-    hass.async_create_task(async_update_sources_from_sonos(hass))
+    from homeassistant.core import EVENT_HOMEASSISTANT_STARTED
+
+    async def _delayed_load(_: object) -> None:
+        await async_update_sources_from_sonos(hass)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _delayed_load)
 
     # Load the sensor and switch platforms and pass the configuration to them
     create_sensors = ags_config.get('create_sensors', False)

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -119,6 +119,10 @@ async def async_setup(hass, config):
 
     hass.services.async_register(DOMAIN, 'load_sonos_favorites', _service_load_favorites)
 
+    # Populate sources list from Sonos favorites on startup
+    from .ags_service import async_update_sources_from_sonos
+    hass.async_create_task(async_update_sources_from_sonos(hass))
+
     # Load the sensor and switch platforms and pass the configuration to them
     create_sensors = ags_config.get('create_sensors', False)
     if create_sensors:

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -109,7 +109,8 @@ async def async_setup(hass, config):
         'default_on': ags_config.get(CONF_DEFAULT_ON, False),
         'static_name': ags_config.get(CONF_STATIC_NAME, None),
         'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
-        'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY)
+        'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY),
+        'sonos_favorites': []
    }
 
     async def _service_load_favorites(call):

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -649,13 +649,15 @@ async def fetch_sonos_favorites(hass, entity_id):
 async def async_update_sources_from_sonos(hass, entity_id=None):
     """Fetch favorites from Sonos and merge into the configured source list."""
     if not entity_id:
-        for room in hass.data["ags_service"]["rooms"]:
-            for device in room["devices"]:
-                if device["device_type"] == "speaker":
-                    entity_id = device["device_id"]
-                    break
-            if entity_id:
-                break
+        speakers = [
+            device
+            for room in hass.data["ags_service"]["rooms"]
+            for device in room["devices"]
+            if device["device_type"] == "speaker"
+        ]
+        if speakers:
+            speakers.sort(key=lambda x: x.get("priority", 0))
+            entity_id = speakers[0]["device_id"]
 
     if not entity_id:
         _LOGGER.error("No speaker found to fetch favorites")

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -691,7 +691,7 @@ async def async_update_sources_from_sonos(hass, entity_id=None):
 
     favorites = await fetch_sonos_favorites(hass, entity_id)
     if not favorites:
-        return
+        return False
 
     # Store the list of favorite titles so a sensor can expose them
     hass.data['ags_service']['sonos_favorites'] = [f.get('Source') for f in favorites]
@@ -712,6 +712,8 @@ async def async_update_sources_from_sonos(hass, entity_id=None):
             player = component.get_entity(ent_id)
             if player:
                 player.async_schedule_update_ha_state(True)
+
+    return True
 
 
 

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -601,11 +601,13 @@ def ags_select_source(ags_config, hass):
 
 async def fetch_sonos_favorites(hass, entity_id):
     """Return favorites for the given Sonos speaker."""
+    component = hass.data.get("media_player")
+    player = component.get_entity(entity_id) if component else None
+    if not player or not hasattr(player, "async_browse_media"):
+        _LOGGER.error("Unable to browse media - invalid player %s", entity_id)
+        return []
+
     try:
-        component = hass.data.get("media_player")
-        player = component.get_entity(entity_id) if component else None
-        if not player or not hasattr(player, "async_browse_media"):
-            raise ValueError("Invalid player: %s" % entity_id)
         root = await player.async_browse_media()
     except Exception as exc:
         _LOGGER.error("Unable to browse media on %s: %s", entity_id, exc)

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -602,8 +602,11 @@ def ags_select_source(ags_config, hass):
 async def fetch_sonos_favorites(hass, entity_id):
     """Return favorites for the given Sonos speaker."""
     try:
-        from homeassistant.components.media_player import async_browse_media
-        root = await async_browse_media(hass, entity_id)
+        component = hass.data.get("media_player")
+        player = component.get_entity(entity_id) if component else None
+        if not player or not hasattr(player, "async_browse_media"):
+            raise ValueError("Invalid player: %s" % entity_id)
+        root = await player.async_browse_media()
     except Exception as exc:
         _LOGGER.error("Unable to browse media on %s: %s", entity_id, exc)
         return []

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -600,7 +600,13 @@ def ags_select_source(ags_config, hass):
 
 
 async def fetch_sonos_favorites(hass, entity_id):
-    """Return favorites for the given Sonos speaker."""
+    """Return favorites for the given Sonos speaker.
+
+    The function issues ``async_browse_media`` on the target entity and walks
+    the returned ``Favorites`` directory. Each leaf node is converted to a dict
+    containing ``Source`` (the title), ``Source_Value`` (``media_content_id``)
+    and ``media_content_type`` so it can be merged into the AGS ``Sources`` list.
+    """
     component = hass.data.get("media_player")
     player = component.get_entity(entity_id) if component else None
     if not player or not hasattr(player, "async_browse_media"):
@@ -649,7 +655,14 @@ async def fetch_sonos_favorites(hass, entity_id):
 
 
 async def async_update_sources_from_sonos(hass, entity_id=None):
-    """Fetch favorites from Sonos and merge into the configured source list."""
+    """Fetch favorites from Sonos and merge them into ``hass.data['ags_service']['Sources']``.
+
+    If ``entity_id`` is omitted, the highest priority speaker from the
+    configuration is used. Each favorite returned by
+    :func:`fetch_sonos_favorites` is appended to the list when its ``Source``
+    title isn't already present. ``media_content_type`` defaults to
+    ``favorite_item_id`` so items play correctly through ``play_media``.
+    """
     if not entity_id:
         speakers = [
             device

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -651,6 +651,17 @@ async def fetch_sonos_favorites(hass, entity_id):
                 )
 
     walk(favorites_dir)
+
+    if not favorites:
+        slist = get_val(player, "source_list") or []
+        favorites = [
+            {
+                "Source": title,
+                "Source_Value": title,
+                "media_content_type": "favorite_item_id",
+            }
+            for title in slist
+        ]
     return favorites
 
 

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -682,6 +682,9 @@ async def async_update_sources_from_sonos(hass, entity_id=None):
     if not favorites:
         return
 
+    # Store the list of favorite titles so a sensor can expose them
+    hass.data['ags_service']['sonos_favorites'] = [f.get('Source') for f in favorites]
+
     sources = hass.data["ags_service"].get("Sources", [])
     existing = {src["Source"] for src in sources}
     for fav in favorites:

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -673,6 +673,15 @@ async def async_update_sources_from_sonos(hass, entity_id=None):
             sources.append(fav)
     hass.data["ags_service"]["Sources"] = sources
 
+    # Refresh sensors and media players so the new sources appear immediately
+    update_ags_sensors(hass.data["ags_service"], hass)
+    component = hass.data.get("media_player")
+    if component:
+        for ent_id in ["media_player.ags_media_player", "media_player.ags_homekit_media_system"]:
+            player = component.get_entity(ent_id)
+            if player:
+                player.async_schedule_update_ha_state(True)
+
 
 
 

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -598,7 +598,8 @@ def ags_select_source(ags_config, hass):
 async def fetch_sonos_favorites(hass, entity_id):
     """Return favorites for the given Sonos speaker."""
     try:
-        root = await hass.components.media_player.browse_media(entity_id)
+        from homeassistant.components.media_player import async_browse_media
+        root = await async_browse_media(hass, entity_id)
     except Exception as exc:
         _LOGGER.error("Unable to browse media on %s: %s", entity_id, exc)
         return []

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -300,6 +300,10 @@ def determine_primary_speaker(ags_config, hass):
             lambda: hass.async_create_task(_delayed_check())
         )
 
+        preferred = hass.data.get('preferred_primary_speaker')
+        if preferred and preferred != "none":
+            primary_speaker = preferred
+
     # Store the immediate result
     hass.data['primary_speaker'] = primary_speaker
 

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.4.4"
+  "version": "1.4.5"
 }

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.4.3"
+  "version": "1.4.4"
 }

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -428,16 +428,13 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         if not self.primary_speaker_entity_id:
             return None
         try:
-            from homeassistant.components.media_player import async_browse_media
+            component = self.hass.data.get("media_player")
+            player = component.get_entity(self.primary_speaker_entity_id) if component else None
+            if player and hasattr(player, "async_browse_media"):
+                return await player.async_browse_media(media_content_type, media_content_id)
         except Exception as exc:
-            _LOGGER.error("Failed importing async_browse_media: %s", exc)
-            return None
-        return await async_browse_media(
-            self.hass,
-            self.primary_speaker_entity_id,
-            media_content_type=media_content_type,
-            media_content_id=media_content_id,
-        )
+            _LOGGER.error("Failed to browse media: %s", exc)
+        return None
            
 
     @property

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -332,6 +332,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
             | MPFeature.VOLUME_SET
             | MPFeature.TURN_ON
             | MPFeature.TURN_OFF
+            | MPFeature.BROWSE_MEDIA
         )
 
     # Implement methods to control the AGS Primary Speaker
@@ -419,6 +420,16 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         ags_select_source(self.ags_config, self.hass)
         self._schedule_ags_update()
+
+    async def async_browse_media(self, media_content_type=None, media_content_id=None):
+        """Delegate media browsing to the primary speaker."""
+        if not self.primary_speaker_entity_id:
+            return None
+        return await self.hass.components.media_player.browse_media(
+            self.primary_speaker_entity_id,
+            media_content_id,
+            media_content_type,
+        )
            
 
     @property
@@ -492,6 +503,7 @@ class MediaSystemMediaPlayer(MediaPlayerEntity):
             | MPFeature.TURN_ON
             | MPFeature.TURN_OFF
             | MPFeature.VOLUME_SET
+            | MPFeature.BROWSE_MEDIA
         )
 
     @property
@@ -545,6 +557,9 @@ class MediaSystemMediaPlayer(MediaPlayerEntity):
     def media_pause(self):
         """Pause the media."""
         self._primary_player.media_pause()
+
+    async def async_browse_media(self, media_content_type=None, media_content_id=None):
+        return await self._primary_player.async_browse_media(media_content_type, media_content_id)
 
     @property
     def device_class(self):

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -335,6 +335,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
             | MPFeature.TURN_ON
             | MPFeature.TURN_OFF
             | MPFeature.BROWSE_MEDIA
+            | MPFeature.PLAY_MEDIA
         )
 
     # Implement methods to control the AGS Primary Speaker
@@ -356,6 +357,18 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self._schedule_media_call('media_stop', {
             'entity_id': self.primary_speaker_entity_id
         })
+        self._schedule_ags_update()
+
+    async def async_play_media(self, media_type, media_id, **kwargs):
+        """Forward the play_media request to the primary speaker."""
+        self._schedule_media_call(
+            'play_media',
+            {
+                'entity_id': self.primary_speaker_entity_id,
+                'media_content_id': media_id,
+                'media_content_type': media_type,
+            },
+        )
         self._schedule_ags_update()
 
     def media_next_track(self):
@@ -509,6 +522,7 @@ class MediaSystemMediaPlayer(MediaPlayerEntity):
             | MPFeature.TURN_OFF
             | MPFeature.VOLUME_SET
             | MPFeature.BROWSE_MEDIA
+            | MPFeature.PLAY_MEDIA
         )
 
     @property
@@ -562,6 +576,9 @@ class MediaSystemMediaPlayer(MediaPlayerEntity):
     def media_pause(self):
         """Pause the media."""
         self._primary_player.media_pause()
+
+    async def async_play_media(self, media_type, media_id, **kwargs):
+        await self._primary_player.async_play_media(media_type, media_id, **kwargs)
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         return await self._primary_player.async_browse_media(media_content_type, media_content_id)

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -425,10 +425,16 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         """Delegate media browsing to the primary speaker."""
         if not self.primary_speaker_entity_id:
             return None
-        return await self.hass.components.media_player.browse_media(
+        try:
+            from homeassistant.components.media_player import async_browse_media
+        except Exception as exc:
+            _LOGGER.error("Failed importing async_browse_media: %s", exc)
+            return None
+        return await async_browse_media(
+            self.hass,
             self.primary_speaker_entity_id,
-            media_content_id,
-            media_content_type,
+            media_content_type=media_content_type,
+            media_content_id=media_content_id,
         )
            
 

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -122,6 +122,8 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self.inactive_speakers = self.hass.data.get('inactive_speakers', None)
         self.primary_speaker = self.hass.data.get('primary_speaker', "")
         self.preferred_primary_speaker = self.hass.data.get('preferred_primary_speaker', None)
+        if not self.primary_speaker or self.primary_speaker == "none":
+            self.primary_speaker = self.preferred_primary_speaker
         # Determine the currently selected source. Historically the attribute
         # ``ags_source`` was expected to expose the numeric Sonos favorite ID so
         # that automations could directly feed it to ``media_player.play_media``.
@@ -157,7 +159,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         found_room = False
         for room in self.ags_config['rooms']:
             for device in room["devices"]:
-                if device["device_id"] == self.hass.data.get('primary_speaker'):
+                if device["device_id"] == self.primary_speaker:
                     self.primary_speaker_room = room["room"]
                     found_room = True
                     break

--- a/custom_components/ags_service/sensor.py
+++ b/custom_components/ags_service/sensor.py
@@ -31,7 +31,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         PrimarySpeakerSensor(hass),
         PreferredPrimarySpeakerSensor(hass),
         AGSSourceSensor( hass),
-        AGSInactiveTVSpeakersSensor(hass)
+        AGSInactiveTVSpeakersSensor(hass),
+        AGSSonosFavoritesSensor(hass)
     ]
 
 
@@ -269,6 +270,26 @@ class AGSInactiveTVSpeakersSensor(SensorEntity):
     def state(self):
         ags_inactive_tv_speakers = self.hass.data.get('ags_inactive_tv_speakers', None)
         return ags_inactive_tv_speakers
+
+
+# Sensor listing the Sonos favorites discovered automatically
+class AGSSonosFavoritesSensor(SensorEntity):
+    """Represent the list of Sonos favorites AGS has loaded."""
+
+    def __init__(self, hass):
+        self.hass = hass
+
+    @property
+    def unique_id(self):
+        return "ags_sonos_favorites"
+
+    @property
+    def name(self):
+        return "AGS Sonos Favorites"
+
+    @property
+    def state(self):
+        return self.hass.data.get('ags_service', {}).get('sonos_favorites')
    
 
 

--- a/custom_components/ags_service/sensor.py
+++ b/custom_components/ags_service/sensor.py
@@ -203,6 +203,8 @@ class PrimarySpeakerSensor(SensorEntity):
     @property
     def state(self):
         primary_speaker = self.hass.data.get('primary_speaker', None)
+        if not primary_speaker or primary_speaker == "none":
+            primary_speaker = self.hass.data.get('preferred_primary_speaker', None)
         return primary_speaker
 
     


### PR DESCRIPTION
## Summary
- add `load_sonos_favorites` service for automatically appending Sonos favorites to the configured Sources list
- implement media browser support on AGS media players
- bump integration version to 1.4.0 and document new service

## Testing
- `python3 -m py_compile custom_components/ags_service/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6863612989648330851a9dc4fc3d87ab