### PR TITLE
Check AGS Actions switch before running media controls

### DIFF
--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -435,7 +435,9 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         """Select the desired source and play it on the primary speaker."""
         self.hass.data["ags_media_player_source"] = source
 
-        ags_select_source(self.ags_config, self.hass)
+        actions_enabled = self.hass.data.get("switch.ags_actions", True)
+        if actions_enabled:
+            ags_select_source(self.ags_config, self.hass)
         self._schedule_ags_update()
            
 


### PR DESCRIPTION
## Summary
- check global Actions switch before selecting source
- gate join/unjoin in `speaker_status_check`
- skip TV or music source selection when actions disabled
- respect switch from media player helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68653cc19b148330bf70801a494ea453