### PR TITLE
Ensure preferred primary controls TV

### DIFF
--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -756,6 +756,25 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
                 hass, primary_speaker=primary_val, preferred_primary=preferred_val
             )
 
+            if (
+                new_status == "ON TV"
+                and preferred_val not in (None, "none")
+                and primary_val not in (None, "none")
+                and primary_val != preferred_val
+            ):
+                active = results["active_speakers"]
+                if active:
+                    await enqueue_media_action(hass, "unjoin", {"entity_id": active})
+                    members = [spk for spk in active if spk != preferred_val]
+                    if members:
+                        await enqueue_media_action(
+                            hass,
+                            "join",
+                            {"entity_id": preferred_val, "group_members": members},
+                        )
+                hass.data["primary_speaker"] = preferred_val
+                primary_val = preferred_val
+
             primary_to_use = primary_val if primary_val not in (None, "none") else preferred_val
 
             message_parts = [

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -752,28 +752,18 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
             primary_val = hass.data.get("primary_speaker")
             preferred_val = hass.data.get("preferred_primary_speaker")
 
-            results = await speaker_status_check(
-                hass, primary_speaker=primary_val, preferred_primary=preferred_val
-            )
-
             if (
                 new_status == "ON TV"
                 and preferred_val not in (None, "none")
                 and primary_val not in (None, "none")
                 and primary_val != preferred_val
             ):
-                active = results["active_speakers"]
-                if active:
-                    await enqueue_media_action(hass, "unjoin", {"entity_id": active})
-                    members = [spk for spk in active if spk != preferred_val]
-                    if members:
-                        await enqueue_media_action(
-                            hass,
-                            "join",
-                            {"entity_id": preferred_val, "group_members": members},
-                        )
                 hass.data["primary_speaker"] = preferred_val
                 primary_val = preferred_val
+
+            results = await speaker_status_check(
+                hass, primary_speaker=primary_val, preferred_primary=preferred_val
+            )
 
             primary_to_use = primary_val if primary_val not in (None, "none") else preferred_val
 

--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -127,16 +127,6 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
             and preferred != "none"
             and primary != preferred
         ):
-            active = self.hass.data.get("active_speakers", [])
-            if active:
-                await enqueue_media_action(self.hass, "unjoin", {"entity_id": active})
-                join_members = [spk for spk in active if spk != preferred]
-                if join_members:
-                    await enqueue_media_action(
-                        self.hass,
-                        "join",
-                        {"entity_id": preferred, "group_members": join_members},
-                    )
             self.hass.data["primary_speaker"] = preferred
             primary = preferred
 


### PR DESCRIPTION
## Summary
- regroup with preferred primary speaker before selecting TV source
- regroup if room switch toggled while on TV

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865434e085c8330b4c6a6448b190e13