### PR TITLE
Implement regroup_with_preferred logic

### DIFF
--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -686,6 +686,7 @@ async def regroup_with_preferred(hass: HomeAssistant, preferred: str) -> None:
     if not active_speakers:
         return
     await enqueue_media_action(hass, "unjoin", {"entity_id": active_speakers})
+    await enqueue_media_action(hass, "delay", {"seconds": 0.5})
     remaining_members = [spk for spk in active_speakers if spk != preferred]
     if remaining_members:
         await enqueue_media_action(

--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -115,8 +115,13 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         if not actions_enabled:
             return
         primary = self.hass.data.get("primary_speaker")
+        preferred = self.hass.data.get("preferred_primary_speaker")
+        if current_status == "ON TV" and preferred and preferred != "none" and preferred != primary:
+            await ags.regroup_with_preferred(self.hass, preferred)
+            self.hass.data["primary_speaker"] = preferred
+            primary = preferred
         if not primary or primary == "none":
-            primary = self.hass.data.get("preferred_primary_speaker")
+            primary = preferred
         if not primary or primary == "none":
             return
         members = [


### PR DESCRIPTION
## Summary
- add regroup_with_preferred helper to rebuild groups around preferred speaker
- use regroup_with_preferred when switching to TV and preferred speaker differs
- regroup first-room joins on TV to preferred speaker

## Testing
- `python -m py_compile custom_components/ags_service/ags_service.py custom_components/ags_service/switch.py`

------
https://chatgpt.com/codex/tasks/task_e_6865610325ec8330934d1d9af211fc21