### PR TITLE
Add action queue synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The integration continuously tracks room occupancy and speaker states, regroupin
 * [Configuration](#configuration)
 * [Automation](#automation)
 * [Service Logic](#service-logic)
+* [Action Queue](#action-queue)
 * [Sensor Logic](#sensor-logic)
 * [License](#license)
 * [Changelog](#changelog)
@@ -191,6 +192,10 @@ AGS evaluates several conditions to decide when to play and which speaker should
 `determine_primary_speaker` sorts devices in each active room by priority and picks the first playing speaker. If none are found it immediately falls back to the preferred device.
 
 `execute_ags_logic` uses the sensor data to join active speakers, unjoin inactive ones and reset TV speakers back to the TV source when required.
+
+## Action Queue
+
+Media actions are executed through a dedicated queue so speakers are joined and unjoined in order.  The new `wait_for_actions` helper blocks until all queued calls have finished.  Room switches and status changes now call this function before refreshing sensors or sending notifications so the system state always reflects the completed actions.
 
 ## Sensor Logic
 

--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -12,6 +12,7 @@ from .ags_service import (
     get_active_rooms,
     ensure_action_queue,
     enqueue_media_action,
+    wait_for_actions,
     update_ags_sensors,
     ags_select_source,
 )
@@ -141,6 +142,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
                     self.hass.data["ags_service"],
                     self.hass,
                 )
+        await wait_for_actions(self.hass)
         await update_ags_sensors(self.hass.data["ags_service"], self.hass)
 
     async def _maybe_unjoin(self) -> None:
@@ -176,7 +178,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         active_rooms = get_active_rooms(rooms, self.hass)
         if not active_rooms:
             await enqueue_media_action(self.hass, "media_stop", {"entity_id": members})
-
+        await wait_for_actions(self.hass)
         await update_ags_sensors(self.hass.data["ags_service"], self.hass)
 
 class AGSActionsSwitch(SwitchEntity, RestoreEntity):


### PR DESCRIPTION
## Summary
- implement `wait_for_actions` helper
- wait for queued actions in switch operations
- ensure status change waits for media actions
- document the action queue and synchronization behaviour

## Testing
- `pytest -q`
- `python -m py_compile custom_components/ags_service/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68657319ad3c8330b943d6aa519b95ec