### PR TITLE
Ensure unjoin waits for speaker to leave group

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ AGS evaluates several conditions to decide when to play and which speaker should
 
 `execute_ags_logic` uses the sensor data to join active speakers, unjoin inactive ones and reset TV speakers back to the TV source when required.
 
+### Action Queue
+
+All media player calls are funneled through a queue so operations happen one at a time. Whenever AGS unjoins a speaker it immediately queues a `wait_ungrouped` action. This pause confirms the speaker has fully left its group before any follow‑up commands, like switching TV inputs, are issued.
+
 ## Sensor Logic
 
 Each sensor uses specific logic to report the state of the system:

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -771,6 +771,12 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
             results = await speaker_status_check(
                 hass, primary_speaker=primary_val, preferred_primary=preferred_val
             )
+            if results["unjoined"]:
+                await enqueue_media_action(
+                    hass,
+                    "wait_ungrouped",
+                    {"entity_id": results["unjoined"], "timeout": 3},
+                )
 
             primary_to_use = primary_val if primary_val not in (None, "none") else preferred_val
 

--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -157,14 +157,14 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         if not members:
             return
         await enqueue_media_action(self.hass, "unjoin", {"entity_id": members})
+        await enqueue_media_action(
+            self.hass,
+            "wait_ungrouped",
+            {"entity_id": members, "timeout": 3},
+        )
 
         has_tv = any(d.get("device_type") == "tv" for d in self.room.get("devices", []))
         if has_tv and not self.hass.data["ags_service"].get("disable_Tv_Source"):
-            await enqueue_media_action(
-                self.hass,
-                "wait_ungrouped",
-                {"entity_id": members, "timeout": 3},
-            )
             for member in members:
                 await enqueue_media_action(
                     self.hass,


### PR DESCRIPTION
## Summary
- unconditionally wait for ungrouping after unjoin in `RoomSwitch`
- queue wait step for any unjoins triggered by `handle_ags_status_change`
- document action queue behavior

## Testing
- `python -m py_compile custom_components/ags_service/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68657aac5968833088902ebad37c3209