### PR TITLE
Ensure status refresh waits for actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ Each sensor uses specific logic to report the state of the system:
 * **AGS Service Source** – numeric media source value for the selected item.
 * **AGS Service Inactive TV Speakers** – speakers attached to TVs that are currently inactive.
 
+## Action Queue
+
+AGS queues all `media_player` service calls to avoid race conditions while grouping speakers.
+All status calculations now wait for queued actions to finish before sensors refresh, ensuring the
+latest group state is used.
+
 ## License
 
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -46,6 +46,12 @@ async def enqueue_media_action(hass: HomeAssistant, service: str, data: dict) ->
     await _ACTION_QUEUE.put((service, data))
 
 
+async def wait_for_actions(hass: HomeAssistant) -> None:
+    """Pause until the action queue has been processed."""
+    await ensure_action_queue(hass)
+    await _ACTION_QUEUE.join()
+
+
 async def _wait_until_ungrouped(
     hass: HomeAssistant, entity_ids: list[str] | str, timeout: float = 3.0
 ) -> None:
@@ -715,6 +721,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
     up‑to‑date information.
     """
     try:
+        await wait_for_actions(hass)
         await hass.data['ags_service']['update_event'].wait()
 
         rooms = ags_config["rooms"]

--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -12,6 +12,7 @@ from .ags_service import (
     get_active_rooms,
     ensure_action_queue,
     enqueue_media_action,
+    wait_for_actions,
     update_ags_sensors,
     ags_select_source,
 )
@@ -103,6 +104,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         prev_primary: str | None = None,
     ) -> None:
         """Join this room's speaker to the primary group if allowed."""
+        await wait_for_actions(self.hass)
         await update_ags_sensors(self.hass.data["ags_service"], self.hass)
         current_status = self.hass.data.get("ags_status")
         if current_status == "OFF":
@@ -145,6 +147,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
 
     async def _maybe_unjoin(self) -> None:
         """Unjoin this room's speaker from any group if allowed."""
+        await wait_for_actions(self.hass)
         await update_ags_sensors(self.hass.data["ags_service"], self.hass)
         actions_enabled = self.hass.data.get("switch.ags_actions", True)
         if not actions_enabled:


### PR DESCRIPTION
## Summary
- introduce `wait_for_actions` helper
- wait for pending actions before updating sensors in switch joins/unjoins
- wait before processing status changes
- document action queue waiting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68657aabec6883308185be761de4bbac