### PR TITLE
Improve TV source selection with preferred primary

### DIFF
--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -15,6 +15,7 @@ from .ags_service import (
     wait_for_actions,
     update_ags_sensors,
     ags_select_source,
+    ensure_preferred_primary_tv,
 )
 from . import ags_service as ags
 
@@ -131,8 +132,8 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         )
         if first_room:
             if current_status == "ON TV":
-                preferred = self.hass.data.get("preferred_primary_speaker")
-                if preferred and preferred != "none":
+                preferred = await ensure_preferred_primary_tv(self.hass)
+                if preferred:
                     await enqueue_media_action(
                         self.hass,
                         "select_source",


### PR DESCRIPTION
## Summary
- add utilities for grouping with preferred primary speaker when playing TV
- use new helper when AGS enters ON TV state
- ensure first-room joins use preferred primary before TV source selection

## Testing
- `python -m py_compile custom_components/ags_service/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68658afc4dd48330810eea55ed966616