### PR TITLE
Restrict music source switch while speaker playing

### DIFF
--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -628,7 +628,9 @@ async def ags_select_source(ags_config, hass):
                 {"source": source, "entity_id": primary_speaker_entity_id},
             )
 
-        elif source != "Unknown" and status != "OFF":
+        elif source != "Unknown" and status == "ON":
+            if state.state == "playing" and state.attributes.get("source") != "TV":
+                return
             source_info = source_dict.get(source)
 
             if source_info:


### PR DESCRIPTION
## Summary
- limit `ags_select_source` so music source is only set when AGS status is `ON`
- avoid switching from a non-TV source if the speaker is already playing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865915ca3948330b481fefd3b8e57cb