### PR TITLE
Delay initial status message

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 # Changelog
 
 ### v1.3.7
-- Initial status notification waits until a primary speaker is found, retrying after 5 seconds if necessary
+- Initial status notification waits until a preferred primary speaker or active room is found, retrying after 5 seconds if necessary
 
 ### v1.3.6
 - Restored the TV source reset when a room turns off

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 
 # Changelog
 
+### v1.3.7
+- Initial status notification waits until a primary speaker is found, retrying after 5 seconds if necessary
+
 ### v1.3.6
 - Restored the TV source reset when a room turns off
 - Delay the source change slightly so the unjoin completes without errors

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -776,7 +776,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
             new_status in ("ON", "ON TV")
             and (
                 not hass.data.get("active_rooms")
-                or hass.data.get("primary_speaker") in (None, "none")
+                or hass.data.get("preferred_primary_speaker") in (None, "none")
             )
         ):
             hass.helpers.event.async_call_later(

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -772,6 +772,22 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
         await wait_for_actions(hass)
         await hass.data['ags_service']['update_event'].wait()
 
+        if (
+            new_status in ("ON", "ON TV")
+            and (
+                not hass.data.get("active_rooms")
+                or hass.data.get("primary_speaker") in (None, "none")
+            )
+        ):
+            hass.helpers.event.async_call_later(
+                hass,
+                5,
+                lambda *_: hass.async_create_task(
+                    handle_ags_status_change(hass, ags_config, new_status, old_status)
+                ),
+            )
+            return
+
         rooms = ags_config["rooms"]
         actions_enabled = hass.data.get("switch.ags_actions", True)
 


### PR DESCRIPTION
## Summary
- avoid 'primary: none' by retrying AGS status change when no rooms or primary speaker
- document notification retry in README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686591df70048330920162587352a176