### PR TITLE
Remove unused send_notification helper

### DIFF
--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -656,9 +656,6 @@ async def ags_select_source(ags_config, hass):
     return
 
 
-async def send_notification(hass: HomeAssistant, title: str, message: str) -> None:
-    return
-
 
 async def speaker_status_check(
     hass,


### PR DESCRIPTION
## Summary
- remove the placeholder `send_notification` function

## Testing
- `python -m compileall -q custom_components/ags_service`

------
https://chatgpt.com/codex/tasks/task_e_6865a4c8e2a08330891a25ee1f89ad34