### PR TITLE
Update join logic to use active speakers

### DIFF
--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -104,7 +104,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         first_room: bool = False,
         prev_primary: str | None = None,
     ) -> None:
-        """Join this room's speaker to the primary group if allowed."""
+        """Join all active speakers to the primary group if allowed."""
         await update_ags_sensors(self.hass.data["ags_service"], self.hass)
         current_status = self.hass.data.get("ags_status")
         if current_status == "OFF":
@@ -117,11 +117,8 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
             primary = self.hass.data.get("preferred_primary_speaker")
         if not primary or primary == "none":
             return
-        members = [
-            d["device_id"]
-            for d in self.room.get("devices", [])
-            if d.get("device_type") == "speaker"
-        ]
+        active_speakers = self.hass.data.get("active_speakers", [])
+        members = [spk for spk in active_speakers if spk != primary]
         if not members:
             return
         await enqueue_media_action(


### PR DESCRIPTION
## Summary
- when a room switch is turned on, join all active speakers to the primary group

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6865b07dfddc8330b4d29ae42cd8c4d0