### PR TITLE
Fix async scheduling for source selection

### DIFF
--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -438,7 +438,11 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         actions_enabled = self.hass.data.get("switch.ags_actions", True)
         if actions_enabled:
-            ags_select_source(self.ags_config, self.hass)
+            self.hass.loop.call_soon_threadsafe(
+                lambda: self.hass.async_create_task(
+                    ags_select_source(self.ags_config, self.hass)
+                )
+            )
         self._schedule_ags_update()
            
 


### PR DESCRIPTION
## Summary
- schedule `ags_select_source` on the Home Assistant event loop instead of calling it directly

## Testing
- `python -m py_compile custom_components/ags_service/media_player.py`
- `find custom_components -name "*.py" -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6865b31b544483309a03f9f7fd1b249e