### PR TITLE
Add playlist clear after stopping media

### DIFF
--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -780,6 +780,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
                         )
                 else:
                     await enqueue_media_action(hass, "media_stop", {"entity_id": members})
+                    await enqueue_media_action(hass, "clear_playlist", {"entity_id": members})
 
         elif new_status in ("ON", "ON TV"):
             primary_val = hass.data.get("primary_speaker")

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -372,6 +372,9 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self._schedule_media_call('media_stop', {
             'entity_id': self.primary_speaker_entity_id
         })
+        self._schedule_media_call('clear_playlist', {
+            'entity_id': self.primary_speaker_entity_id
+        })
         self._schedule_ags_update()
 
     def media_next_track(self):

--- a/custom_components/ags_service/switch.py
+++ b/custom_components/ags_service/switch.py
@@ -176,6 +176,7 @@ class RoomSwitch(SwitchEntity, RestoreEntity):
         active_rooms = get_active_rooms(rooms, self.hass)
         if not active_rooms:
             await enqueue_media_action(self.hass, "media_stop", {"entity_id": members})
+            await enqueue_media_action(self.hass, "clear_playlist", {"entity_id": members})
         await wait_for_actions(self.hass)
 
         await update_ags_sensors(self.hass.data["ags_service"], self.hass)


### PR DESCRIPTION
## Summary
- queue clear_playlist after media_stop when switches power off speakers
- apply same behavior in ags_service when rooms stop
- call clear_playlist after media_stop from AGS media player

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a8fd794d883308ca212c0a9ef59bb