### PR TITLE
Add configurable logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ ags_service:
 * **homekit_player**, **create_sensors**, **default_on**, **static_name**, **disable_Tv_Source**, and **interval_sync** are optional tweaks. See example for placement.
 * If `schedule_override` is enabled, AGS turns off once whenever the schedule switches to its off state but can be manually re-enabled until the schedule turns back on.
 
+### Logging
+
+When `enable_logging` is `true` a new **AGS Logging** switch is created. Toggle this entity to turn verbose logging on or off without editing YAML. Messages appear in Home Assistant's log at the `INFO` level. To view them, add the following to `configuration.yaml`:
+
+```yaml
+logger:
+  logs:
+    custom_components.ags_service: info
+```
+
 HomeKit does not handle the AGS player's dynamically changing name and TV source list. If you plan to expose the player to HomeKit either specify ``homekit_player`` so a dedicated media player with a static name is created, or enable ``static_name`` and set ``disable_Tv_Source: true`` to keep the main player's name and source list constant.
 
 ## Service Logic

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ ags_service:
 | `static_name` | `none` | Custom name for the AGS Media Player. |
 | `disable_Tv_Source` | `false` | Hide TV source in the static source list. |
 | `ott_device` | _None_ | External player for TVs that use a streaming box or console. AGS pulls play/pause controls from this device when the TV is active (`ON TV`). |
+| `enable_logging` | `false` | Log switch events and commands for troubleshooting. |
 
 ### Reference configuration
 
@@ -131,6 +132,7 @@ ags_service:
 #  default_on: false
 #  static_name: "AGS Media Player"
 #  disable_Tv_Source: false
+#  enable_logging: true
 #  schedule_entity:
 #    entity_id: schedule.my_music
 #    on_state: "on"  # optional

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ ags_service:
 
 ### Logging
 
-When `enable_logging` is `true` a new **AGS Logging** switch is created. Toggle this entity to turn verbose logging on or off without editing YAML. Messages appear in Home Assistant's log at the `INFO` level. To view them, add the following to `configuration.yaml`:
+When `enable_logging` is `true` a new **AGS Logging** switch is created after reloading the integration. Toggle this entity to turn verbose logging on or off without editing YAML. Messages appear in Home Assistant's log at the `INFO` level. To view them, add the following to `configuration.yaml`:
 
 ```yaml
 logger:

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -30,6 +30,7 @@ CONF_SOURCE = 'Source'
 CONF_MEDIA_CONTENT_TYPE = 'media_content_type'
 CONF_SOURCE_VALUE = 'Source_Value'
 CONF_SOURCE_DEFAULT = 'source_default'
+CONF_ENABLE_LOGGING = 'enable_logging'
 
 
 # Define the configuration schema for a device
@@ -84,6 +85,7 @@ DEVICE_SCHEMA = vol.Schema({
         vol.Optional('off_state', default='off'): cv.string,
         vol.Optional('schedule_override', default=False): cv.boolean,
     }),
+    vol.Optional(CONF_ENABLE_LOGGING, default=False): cv.boolean,
 })
 
 async def async_setup(hass, config):
@@ -109,6 +111,7 @@ async def async_setup(hass, config):
         'static_name': ags_config.get(CONF_STATIC_NAME, None),
         'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
         'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY),
+        'enable_logging': ags_config.get(CONF_ENABLE_LOGGING, False),
     }
 
     # Initialize shared media action queue

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -800,6 +800,11 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
                     await enqueue_media_action(hass, "media_stop", {"entity_id": members})
                     await enqueue_media_action(hass, "clear_playlist", {"entity_id": members})
 
+            log_event(
+                hass,
+                f"status {old_status} -> OFF | unjoined all speakers",
+            )
+
         elif new_status in ("ON", "ON TV"):
             primary_val = hass.data.get("primary_speaker")
             preferred_val = hass.data.get("preferred_primary_speaker")
@@ -869,6 +874,10 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
                 if actions_enabled:
                     await ags_select_source(ags_config, hass)
                     message_parts.append("selected music source")
+            log_event(
+                hass,
+                f"status {old_status} -> {new_status} | " + " | ".join(message_parts),
+            )
 
     except Exception as exc:  # pragma: no cover - safety net
         _LOGGER.warning("Error handling AGS status change: %s", exc)


### PR DESCRIPTION
## Summary
- add `enable_logging` option
- log media player commands and switch actions

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac86af95883309c45745da1506a42