### PR TITLE
Add ott device list with tv input matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ags_service:
 | `default_on` | `false` | Start enabled on boot. |
 | `static_name` | `none` | Custom name for the AGS Media Player. |
 | `disable_Tv_Source` | `false` | Hide TV source in the static source list. |
-| `ott_devices` | _None_ | List of streaming boxes or consoles with their TV inputs. When the TV speaker source matches an entry's `tv_input`, AGS uses the corresponding `ott_device` for control. Both `ott_device` and `tv_input` are required for each entry. |
+| `ott_devices` | _None_ | List of streaming boxes or consoles with their TV inputs. When the TV's current input matches an entry's `tv_input`, AGS uses the corresponding `ott_device` for control. Both `ott_device` and `tv_input` are required for each entry. |
 
 ### Reference configuration
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ags_service:
 | `default_on` | `false` | Start enabled on boot. |
 | `static_name` | `none` | Custom name for the AGS Media Player. |
 | `disable_Tv_Source` | `false` | Hide TV source in the static source list. |
-| `ott_device` | _None_ | External player for TVs that use a streaming box or console. AGS pulls play/pause controls from this device when the TV is active (`ON TV`). |
+| `ott_devices` | _None_ | List of streaming boxes or consoles with their TV inputs. When the TV speaker source matches an entry's `tv_input`, AGS uses the corresponding `ott_device` for control. Both `ott_device` and `tv_input` are required for each entry. |
 
 ### Reference configuration
 
@@ -142,7 +142,9 @@ ags_service:
         - device_id: "media_player.device_1"
           device_type: "tv"
           priority: 1
-#          ott_device: "media_player.ott_1"  # optional: streaming box used for playback
+#          ott_devices:
+#            - ott_device: "media_player.ott_1"
+#              tv_input: "HDMI 1"
         - device_id: "media_player.device_2"
           device_type: "speaker"
           priority: 2
@@ -224,6 +226,10 @@ latest group state is used.
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.
 
 # Changelog
+
+### v1.5.0
+- **Breaking change**: `ott_device` has been replaced by an `ott_devices` list. Each entry must define `ott_device` and `tv_input`.
+- Automatically selects the correct OTT device based on the TV's current input.
 
 ### v1.4.1
 - Schedule source selection runs asynchronously

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -25,6 +25,8 @@ CONF_DISABLE_TV_SOURCE = 'disable_Tv_Source'
 CONF_INTERVAL_SYNC = 'interval_sync'
 CONF_SCHEDULE_ENTITY = 'schedule_entity'
 CONF_OTT_DEVICE = 'ott_device'
+CONF_OTT_DEVICES = 'ott_devices'
+CONF_TV_INPUT = 'tv_input'
 CONF_SOURCES = 'Sources'
 CONF_SOURCE = 'Source'
 CONF_MEDIA_CONTENT_TYPE = 'media_content_type'
@@ -49,7 +51,17 @@ DEVICE_SCHEMA = vol.Schema({
                                     vol.Required("device_type"): cv.string,
                                     vol.Required("priority"): cv.positive_int,
                                     vol.Optional("override_content"): cv.string,
-                                    vol.Optional(CONF_OTT_DEVICE): cv.string,
+                                    vol.Optional(CONF_OTT_DEVICES): vol.All(
+                                        cv.ensure_list,
+                                        [
+                                            vol.Schema(
+                                                {
+                                                    vol.Required(CONF_OTT_DEVICE): cv.string,
+                                                    vol.Required(CONF_TV_INPUT): cv.string,
+                                                }
+                                            )
+                                        ],
+                                    ),
                                 }
                             )
                         ],
@@ -91,12 +103,12 @@ async def async_setup(hass, config):
 
     ags_config = config[DOMAIN]
 
-    # Validate ott_device usage
+    # Validate ott_devices usage
     for room in ags_config['rooms']:
         for device in room['devices']:
-            if CONF_OTT_DEVICE in device and device['device_type'] != 'tv':
+            if CONF_OTT_DEVICES in device and device['device_type'] != 'tv':
                 raise vol.Invalid(
-                    "ott_device is only allowed for devices with device_type 'tv'"
+                    "ott_devices is only allowed for devices with device_type 'tv'"
                 )
 
     hass.data[DOMAIN] = {

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -543,9 +543,8 @@ def _select_ott_device(tv_device: dict, hass) -> str:
     if not ott_list:
         return tv_device.get("ott_device", tv_device["device_id"])
 
-    primary_speaker = hass.data.get("primary_speaker")
-    speaker_state = hass.states.get(primary_speaker) if primary_speaker else None
-    current_input = speaker_state.attributes.get("source") if speaker_state else None
+    tv_state = hass.states.get(tv_device["device_id"])
+    current_input = tv_state.attributes.get("source") if tv_state else None
 
     if current_input:
         for entry in ott_list:

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.4.1"
+  "version": "1.5.0"
 }

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -7,7 +7,12 @@ from homeassistant.const import STATE_IDLE, STATE_PLAYING, STATE_PAUSED
 from homeassistant.helpers.event import async_track_state_change_event
 
 import asyncio
-from .ags_service import update_ags_sensors, ags_select_source, get_control_device_id
+from .ags_service import (
+    update_ags_sensors,
+    ags_select_source,
+    get_control_device_id,
+    _select_ott_device,
+)
 
 import logging
 _LOGGER = logging.getLogger(__name__)
@@ -176,7 +181,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
             if sorted_devices:
                 first_device = sorted_devices[0]
-                selected_device_id = first_device.get('ott_device', first_device["device_id"])
+                selected_device_id = _select_ott_device(first_device, self.hass)
             else:
                 selected_device_id = self.hass.data.get('primary_speaker', None)
 


### PR DESCRIPTION
## Summary
- allow TVs to define `ott_devices` list
- pick OTT device based on TV input
- document that each entry requires `ott_device` and `tv_input`
- bump version to 1.5.0

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68716303d3d483308ba5fb99aa19edb5