### PR TITLE
Support default OTT device fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ags_service:
 | `default_on` | `false` | Start enabled on boot. |
 | `static_name` | `none` | Custom name for the AGS Media Player. |
 | `disable_Tv_Source` | `false` | Hide TV source in the static source list. |
-| `ott_devices` | _None_ | List of streaming boxes or consoles with their TV inputs. When the TV's current input matches an entry's `tv_input`, AGS uses the corresponding `ott_device` for control. Both `ott_device` and `tv_input` are required for each entry. |
+| `ott_devices` | _None_ | List of streaming boxes or consoles with their TV inputs. When the TV's current input matches an entry's `tv_input`, AGS uses the corresponding `ott_device` for control. You may set `default: true` on one entry to use that OTT device when no inputs match. If no default is set the TV device itself is used. `ott_device` and `tv_input` are required for each entry. |
 
 ### Reference configuration
 
@@ -145,6 +145,9 @@ ags_service:
 #          ott_devices:
 #            - ott_device: "media_player.ott_1"
 #              tv_input: "HDMI 1"
+#            - ott_device: "media_player.apple_tv"
+#              tv_input: "HDMI 2"
+#              default: true
         - device_id: "media_player.device_2"
           device_type: "speaker"
           priority: 2
@@ -226,6 +229,9 @@ latest group state is used.
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.
 
 # Changelog
+
+### v1.6.0
+- `ott_devices` entries may include `default: true` to specify the fallback OTT device when no `tv_input` matches. If no default is set AGS uses the TV device.
 
 ### v1.5.0
 - **Breaking change**: `ott_device` has been replaced by an `ott_devices` list. Each entry must define `ott_device` and `tv_input`.

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -58,6 +58,7 @@ DEVICE_SCHEMA = vol.Schema({
                                                 {
                                                     vol.Required(CONF_OTT_DEVICE): cv.string,
                                                     vol.Required(CONF_TV_INPUT): cv.string,
+                                                    vol.Optional("default", default=False): cv.boolean,
                                                 }
                                             )
                                         ],

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -551,7 +551,11 @@ def _select_ott_device(tv_device: dict, hass) -> str:
             if entry.get("tv_input") == current_input:
                 return entry.get("ott_device", tv_device["device_id"])
 
-    return ott_list[0].get("ott_device", tv_device["device_id"])
+    for entry in ott_list:
+        if entry.get("default") is True:
+            return entry.get("ott_device", tv_device["device_id"])
+
+    return tv_device["device_id"]
 
 
 def get_control_device_id(ags_config, hass):


### PR DESCRIPTION
## Summary
- allow marking an OTT device as default in configuration
- use the default OTT device when the TV input does not match any OTT inputs
- document OTT device default behaviour and update example configuration
- note change in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68717bf25e2c8330acab4b47200000fb