### PR TITLE
Implement config entry support

### DIFF
--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -162,8 +162,8 @@ def _handle_status_transition(prev_status, new_status, hass):
 async def update_ags_sensors(ags_config, hass):
     """Refresh AGS related sensor values."""
     rooms = ags_config['rooms']
-    lock = hass.data['ags_service']['sensor_lock']
-    event = hass.data['ags_service']['update_event']
+    lock = ags_config['sensor_lock']
+    event = ags_config['update_event']
 
     async with lock:
         try:
@@ -245,7 +245,7 @@ def update_ags_status(ags_config, hass):
     active_rooms = hass.data.get('active_rooms', [])
     prev_status = hass.data.get('ags_status')
     default_source_name = None
-    sources_list = hass.data['ags_service']['Sources'] 
+    sources_list = ags_config['Sources']
     for src in sources_list:
         if src.get("source_default") == True:
             default_source_name = src["Source"]
@@ -284,7 +284,7 @@ def update_ags_status(ags_config, hass):
 
 
     # Determine schedule entity state if configured
-    schedule_cfg = hass.data['ags_service'].get('schedule_entity')
+    schedule_cfg = ags_config.get('schedule_entity')
     schedule_on = True
     prev_schedule_state = hass.data.get('schedule_prev_state')
     if schedule_cfg:
@@ -608,7 +608,7 @@ async def ags_select_source(ags_config, hass):
             return
         source = hass.data.get('ags_media_player_source')
         if source is None:
-            sources_list = hass.data['ags_service']['Sources']
+            sources_list = ags_config['Sources']
             source = next(
                 (
                     src["Source"]
@@ -640,7 +640,7 @@ async def ags_select_source(ags_config, hass):
             return
 
         # Convert the list of sources to a dictionary for faster lookups
-        sources_list = hass.data['ags_service']['Sources'] 
+        sources_list = ags_config['Sources']
         source_dict = {src["Source"]: {"value": src["Source_Value"], "type": src.get("media_content_type")} for src in sources_list}
 
 
@@ -797,7 +797,7 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
     """
     try:
         await wait_for_actions(hass)
-        await hass.data['ags_service']['update_event'].wait()
+        await ags_config['update_event'].wait()
 
         rooms = ags_config["rooms"]
         actions_enabled = hass.data.get("switch.ags_actions", True)

--- a/custom_components/ags_service/config_flow.py
+++ b/custom_components/ags_service/config_flow.py
@@ -1,0 +1,67 @@
+"""Configuration flow for AGS Service."""
+
+from __future__ import annotations
+
+import yaml
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from . import (
+    DOMAIN,
+    DEVICE_SCHEMA,
+    CONF_ROOMS,
+    CONF_SOURCES,
+)
+
+
+class AGSServiceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for AGS Service."""
+
+    VERSION = 1
+
+    def _validate(self, data: dict) -> dict:
+        """Validate configuration using the same schema as YAML."""
+
+        validated = DEVICE_SCHEMA(data)
+        return validated
+
+    async def async_step_user(self, user_input: dict | None = None):
+        errors = {}
+
+        if user_input is not None:
+            try:
+                rooms = yaml.safe_load(user_input[CONF_ROOMS])
+                sources = yaml.safe_load(user_input[CONF_SOURCES])
+
+                data = {CONF_ROOMS: rooms, CONF_SOURCES: sources}
+
+                if user_input.get("username"):
+                    data["username"] = user_input["username"]
+                if user_input.get("password"):
+                    data["password"] = user_input["password"]
+
+                self._validate(data)
+            except Exception:  # pragma: no cover - validation
+                errors["base"] = "invalid_config"
+            else:
+                return self.async_create_entry(title="AGS Service", data=data)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_ROOMS): str,
+                vol.Required(CONF_SOURCES): str,
+                vol.Optional("username"): str,
+                vol.Optional("password"): str,
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    @callback
+    def async_step_import(self, data: dict):
+        """Handle import from configuration.yaml."""
+
+        return self.async_create_entry(title="AGS Service", data=data)
+

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,6 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.5.0"
+  "config_flow": true,
+  "version": "1.6.1"
 }

--- a/custom_components/ags_service/sensor.py
+++ b/custom_components/ags_service/sensor.py
@@ -10,13 +10,18 @@ SCAN_INTERVAL = timedelta(seconds=30)
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-# Setup platform function
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.event import async_track_state_change_event
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    # Create your sensors
-    ags_config = hass.data['ags_service']
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors from a config entry."""
+
+    ags_config = hass.data["ags_service"][entry.entry_id]
     global SCAN_INTERVAL
     interval = ags_config.get('interval_sync', 30)
     SCAN_INTERVAL = timedelta(seconds=interval)
@@ -45,7 +50,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             await sensor.async_update_ha_state(True)
 
     # Register sensors so other modules can refresh them immediately
-    hass.data['ags_sensors'] = sensors
+    hass.data["ags_service"][entry.entry_id]["sensors"] = sensors
 
     entities_to_track = ['zone.home']
     schedule_cfg = ags_config.get('schedule_entity')


### PR DESCRIPTION
## Summary
- add config entry logic and config flow UI
- bump manifest version and enable config_flow
- use entry-based data storage
- update platforms to setup from entries

## Testing
- `python -m py_compile $(git ls-files "custom_components/ags_service/*.py")`


------
https://chatgpt.com/codex/tasks/task_e_687183533dc48330b470d1732439cd2a