### PR TITLE
Improve AGS OFF handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ ags_service:
 | `default_on` | `false` | Start enabled on boot. |
 | `static_name` | `none` | Custom name for the AGS Media Player. |
 | `disable_Tv_Source` | `false` | Hide TV source in the static source list. |
+| `batch_unjoin` | `false` | Unjoin all speakers at once when turning off. |
 | `ott_device` | _None_ | External player for TVs that use a streaming box or console. AGS pulls play/pause controls from this device when the TV is active (`ON TV`). |
 
 ### Reference configuration
@@ -131,6 +132,7 @@ ags_service:
 #  default_on: false
 #  static_name: "AGS Media Player"
 #  disable_Tv_Source: false
+#  batch_unjoin: false
 #  schedule_entity:
 #    entity_id: schedule.my_music
 #    on_state: "on"  # optional
@@ -223,6 +225,9 @@ latest group state is used.
 This project is released under a Non-Commercial License. See the [LICENSE](LICENSE) file for details.
 
 # Changelog
+
+### v1.4.8
+- Faster AGS OFF logic with optional `batch_unjoin` setting.
 
 ### v1.4.7
 - Last playing speakers now stop when the final room turns off, even if the system status stays ON.

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -25,6 +25,7 @@ CONF_DISABLE_TV_SOURCE = 'disable_Tv_Source'
 CONF_INTERVAL_SYNC = 'interval_sync'
 CONF_SCHEDULE_ENTITY = 'schedule_entity'
 CONF_OTT_DEVICE = 'ott_device'
+CONF_BATCH_UNJOIN = 'batch_unjoin'
 CONF_SOURCES = 'Sources'
 CONF_SOURCE = 'Source'
 CONF_MEDIA_CONTENT_TYPE = 'media_content_type'
@@ -84,6 +85,7 @@ DEVICE_SCHEMA = vol.Schema({
         vol.Optional('off_state', default='off'): cv.string,
         vol.Optional('schedule_override', default=False): cv.boolean,
     }),
+    vol.Optional(CONF_BATCH_UNJOIN, default=False): cv.boolean,
 })
 
 async def async_setup(hass, config):
@@ -109,6 +111,7 @@ async def async_setup(hass, config):
         'static_name': ags_config.get(CONF_STATIC_NAME, None),
         'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
         'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY),
+        'batch_unjoin': ags_config.get(CONF_BATCH_UNJOIN, False),
     }
 
     # Initialize shared media action queue

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.4.7"
+  "version": "1.4.8"
 }


### PR DESCRIPTION
## Summary
- cache device states once when handling state changes
- add `batch_unjoin` option
- make OFF cleanup clearer and faster
- document the new option in README
- bump version to 1.4.8

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718817d10883309c0fbcd8558b7441