### PR TITLE
Adjust schedule on logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ ags_service:
 * **Sources** – static list of available sources for the AGS Media Player. Mark one entry with `source_default: true` to use when no other source is selected.
 * **schedule_entity** – follow another entity's state. `on_state`/`off_state` default to `on`/`off`; `schedule_override` defaults to `false`.
 * **homekit_player**, **create_sensors**, **default_on**, **static_name**, **disable_Tv_Source**, and **interval_sync** are optional tweaks. See example for placement.
-* If `schedule_override` is enabled, AGS turns off once whenever the schedule switches to its off state but can be manually re-enabled until the schedule turns back on.
+* If `schedule_override` is enabled, AGS turns off once whenever the schedule switches to its off state but leaves the current state unchanged when the schedule turns back on.
 
 HomeKit does not handle the AGS player's dynamically changing name and TV source list. If you plan to expose the player to HomeKit either specify ``homekit_player`` so a dedicated media player with a static name is created, or enable ``static_name`` and set ``disable_Tv_Source: true`` to keep the main player's name and source list constant.
 
@@ -187,7 +187,7 @@ HomeKit does not handle the AGS player's dynamically changing name and TV source
 AGS evaluates several conditions to decide when to play and which speaker should be primary:
 
 1. **update_ags_status** checks if `zone.home` is empty unless `disable_zone` is enabled. If nobody is home the status becomes `OFF`.
-2. When a `schedule_entity` is defined the status follows its state. With `schedule_override` disabled the system turns `OFF` whenever the schedule is off.
+2. When a `schedule_entity` is defined the status follows its state. With `schedule_override` disabled the system turns `OFF` whenever the schedule is off and resets to `default_on` when it switches back on.
 3. Devices can define `override_content`. When a playing device's `media_content_id` contains this text the service switches to `Override` and that device becomes the primary speaker.
 4. If any active room has a TV that is on, status changes to `ON TV`.
 5. Otherwise the status is simply `ON`.

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -299,15 +299,15 @@ def update_ags_status(ags_config, hass):
         else:
             schedule_on = False
 
-    # Automatically enable the media system when the schedule switches
-    # from the off state to the on state
+    # When the schedule transitions from the off state to the on state
+    # restore the media system based on the default setting
     if (
         schedule_cfg
         and prev_schedule_state is not None
         and not prev_schedule_state
         and schedule_on
     ):
-        hass.data['switch_media_system_state'] = True
+        hass.data['switch_media_system_state'] = ags_config['default_on']
 
     media_system_state = hass.data.get('switch_media_system_state')
     if media_system_state is None:

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -300,14 +300,16 @@ def update_ags_status(ags_config, hass):
             schedule_on = False
 
     # When the schedule transitions from the off state to the on state
-    # restore the media system based on the default setting
+    # restore the media system based on the default setting unless
+    # schedule_override is enabled
     if (
         schedule_cfg
         and prev_schedule_state is not None
         and not prev_schedule_state
         and schedule_on
     ):
-        hass.data['switch_media_system_state'] = ags_config['default_on']
+        if not schedule_cfg.get('schedule_override'):
+            hass.data['switch_media_system_state'] = ags_config['default_on']
 
     media_system_state = hass.data.get('switch_media_system_state')
     if media_system_state is None:


### PR DESCRIPTION
## Summary
- restore the media system according to `default_on` when schedule turns on

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687190903dfc8330975fc3eaa8f93ed7