### PR TITLE
Implement config entry and reload support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+name: Test
+on: [pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -64,46 +64,24 @@ The integration consists of several Python modules and support files:
 1. Open **HACS → Integrations → ⋮ → Custom repositories**.
 2. Add `https://github.com/ByteRookie/AGS_Service` as a new **Integration** repository.
 3. Search for **AGS Service** in HACS and install it.
-4. Restart Home Assistant.
+4. Reload the UI and add **AGS Service** from **Settings → Devices & Services**.
 
-### Manual Install
-
-1. Download the `ags_service` folder from this repository.
-2. Place it in your `custom_components` directory (create the folder if it does not exist).
-3. Add the configuration details to your `configuration.yaml` file (see below).
-4. Restart Home Assistant.
 
 ## Quick Start
 
 Follow these basic steps to try AGS Service immediately:
 
-1. Install the integration through HACS using the instructions above.
-2. Copy the [minimal configuration](#minimal-configuration) into your `configuration.yaml` file.
-3. Restart Home Assistant. AGS Service manages speaker groups automatically. Starting with v1.4.0 the old `AGS Automation Example.yaml` file is no longer needed because all automation logic is built into the integration.
+1. Install the integration through HACS as described above.
+2. Open **Settings → Devices & Services**, click **Add Integration** and select **AGS Service**.
+3. Enter your rooms and sources in the dialog. Save to create the entry.
+4. Use the integration's **Configure** option later to change rooms or sources. Reload the entry when prompted.
 
 
 ## Configuration
 
-Add the integration to `configuration.yaml`.
+Configure AGS Service entirely from the Integrations UI. When adding the integration you will be prompted for rooms and sources. These values can be edited later via the **Configure** option on the integration card.
 
-### Minimal configuration
-
-Only `rooms` and `Sources` are required:
-
-```yaml
-ags_service:
-  rooms:
-    - room: "Living Room"
-      devices:
-        - device_id: "media_player.living_room"
-          device_type: "speaker"
-          priority: 1
-  Sources:
-    - Source: "Default"
-      Source_Value: "1"
-      media_content_type: "favorite_item_id"
-      source_default: true
-```
+Existing YAML configuration will be imported automatically on first install, but YAML support is now deprecated and should be removed after migration.
 
 ### Optional parameters
 

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -1,143 +1,76 @@
 """Main module for the AGS Service integration."""
 import asyncio
-import voluptuous as vol
 
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
 from .ags_service import ensure_action_queue
-
-# Define the domain for the integration
-DOMAIN = "ags_service"
-
-# Define the configuration keys
-CONF_ROOM = 'room'
-CONF_ROOMS = 'rooms'
-CONF_DEVICE_ID = 'device_id'
-CONF_DEVICE_TYPE = 'device_type'
-CONF_PRIORITY = 'priority'
-CONF_OVERRIDE_CONTENT = 'override_content'
-CONF_DISABLE_ZONE = 'disable_zone'
-CONF_HOMEKIT_PLAYER = 'homekit_player'
-CONF_CREATE_SENSORS = 'create_sensors'
-CONF_DEFAULT_ON = 'default_on'
-CONF_STATIC_NAME = 'static_name'
-CONF_DISABLE_TV_SOURCE = 'disable_Tv_Source'
-CONF_INTERVAL_SYNC = 'interval_sync'
-CONF_SCHEDULE_ENTITY = 'schedule_entity'
-CONF_OTT_DEVICE = 'ott_device'
-CONF_OTT_DEVICES = 'ott_devices'
-CONF_TV_INPUT = 'tv_input'
-CONF_SOURCES = 'Sources'
-CONF_SOURCE = 'Source'
-CONF_MEDIA_CONTENT_TYPE = 'media_content_type'
-CONF_SOURCE_VALUE = 'Source_Value'
-CONF_SOURCE_DEFAULT = 'source_default'
+from .const import (
+    DOMAIN,
+    DEVICE_SCHEMA,
+    CONF_DISABLE_TV_SOURCE,
+    CONF_CREATE_SENSORS,
+    CONF_DEFAULT_ON,
+    CONF_DISABLE_ZONE,
+    CONF_HOMEKIT_PLAYER,
+    CONF_STATIC_NAME,
+    CONF_SCHEDULE_ENTITY,
+    CONF_OTT_DEVICES,
+)
 
 
-# Define the configuration schema for a device
-DEVICE_SCHEMA = vol.Schema({
-    vol.Required("rooms"): vol.All(
-        cv.ensure_list,
-        [
-            vol.Schema(
-                {
-                    vol.Required("room"): cv.string,
-                    vol.Required("devices"): vol.All(
-                        cv.ensure_list,
-                        [
-                            vol.Schema(
-                                {
-                                    vol.Required("device_id"): cv.string,
-                                    vol.Required("device_type"): cv.string,
-                                    vol.Required("priority"): cv.positive_int,
-                                    vol.Optional("override_content"): cv.string,
-                                    vol.Optional(CONF_OTT_DEVICES): vol.All(
-                                        cv.ensure_list,
-                                        [
-                                            vol.Schema(
-                                                {
-                                                    vol.Required(CONF_OTT_DEVICE): cv.string,
-                                                    vol.Required(CONF_TV_INPUT): cv.string,
-                                                    vol.Optional("default", default=False): cv.boolean,
-                                                }
-                                            )
-                                        ],
-                                    ),
-                                }
-                            )
-                        ],
-                    ),
-                }
-            )
-        ],
-    ),
-    vol.Required("Sources"): vol.All(
-        cv.ensure_list,
-        [
-            vol.Schema(
-                {
-                    vol.Required("Source"): cv.string,
-                    vol.Required("Source_Value"): cv.string,
-                    vol.Required(CONF_MEDIA_CONTENT_TYPE): cv.string,
-                    vol.Optional(CONF_SOURCE_DEFAULT, default=False): cv.boolean,
-                }
-            )
-        ],
-    ),
-    vol.Optional(CONF_DISABLE_ZONE, default=False): cv.boolean,
-    vol.Optional(CONF_HOMEKIT_PLAYER, default=None): cv.string,
-    vol.Optional(CONF_CREATE_SENSORS, default=False): cv.boolean,
-    vol.Optional(CONF_DEFAULT_ON, default=False): cv.boolean,
-    vol.Optional(CONF_STATIC_NAME, default=None): cv.string,
-    vol.Optional(CONF_DISABLE_TV_SOURCE, default=False): cv.boolean,
-    vol.Optional(CONF_INTERVAL_SYNC, default=30): cv.positive_int,
-    vol.Optional(CONF_SCHEDULE_ENTITY): vol.Schema({
-        vol.Required('entity_id'): cv.string,
-        vol.Optional('on_state', default='on'): cv.string,
-        vol.Optional('off_state', default='off'): cv.string,
-        vol.Optional('schedule_override', default=False): cv.boolean,
-    }),
-})
 
 async def async_setup(hass, config):
-    """Set up the custom component."""
+    """Import YAML config and start a config entry."""
+    if DOMAIN not in config:
+        return True
 
-    ags_config = config[DOMAIN]
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "import"}, data=config[DOMAIN]
+        )
+    )
+    return True
 
-    # Validate ott_devices usage
-    for room in ags_config['rooms']:
-        for device in room['devices']:
-            if CONF_OTT_DEVICES in device and device['device_type'] != 'tv':
-                raise vol.Invalid(
-                    "ott_devices is only allowed for devices with device_type 'tv'"
-                )
 
-    hass.data[DOMAIN] = {
-        'rooms': ags_config['rooms'],
-        'Sources': ags_config['Sources'],
-        'disable_zone': ags_config.get(CONF_DISABLE_ZONE, False),
-        'homekit_player': ags_config.get(CONF_HOMEKIT_PLAYER, None),
-        'create_sensors': ags_config.get(CONF_CREATE_SENSORS, False),
-        'default_on': ags_config.get(CONF_DEFAULT_ON, False),
-        'static_name': ags_config.get(CONF_STATIC_NAME, None),
-        'disable_Tv_Source': ags_config.get(CONF_DISABLE_TV_SOURCE, False),
-        'schedule_entity': ags_config.get(CONF_SCHEDULE_ENTITY),
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up AGS Service from a config entry."""
+    data = entry.data | entry.options
+    DEVICE_SCHEMA(data)
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {
+        'rooms': data['rooms'],
+        'Sources': data['Sources'],
+        'disable_zone': data.get(CONF_DISABLE_ZONE, False),
+        'homekit_player': data.get(CONF_HOMEKIT_PLAYER, None),
+        'create_sensors': data.get(CONF_CREATE_SENSORS, False),
+        'default_on': data.get(CONF_DEFAULT_ON, False),
+        'static_name': data.get(CONF_STATIC_NAME, None),
+        'disable_Tv_Source': data.get(CONF_DISABLE_TV_SOURCE, False),
+        'schedule_entity': data.get(CONF_SCHEDULE_ENTITY),
     }
 
-    # Initialize shared media action queue
     await ensure_action_queue(hass)
+    hass.data[DOMAIN][entry.entry_id]["sensor_lock"] = asyncio.Lock()
+    hass.data[DOMAIN][entry.entry_id]["update_event"] = asyncio.Event()
 
-    # Initialize synchronization primitives used for sensor updates
-    hass.data[DOMAIN]["sensor_lock"] = asyncio.Lock()
-    hass.data[DOMAIN]["update_event"] = asyncio.Event()
-
-
-    # Load the sensor and switch platforms and pass the configuration to them
-    create_sensors = ags_config.get('create_sensors', False)
+    create_sensors = data.get(CONF_CREATE_SENSORS, False)
+    platforms = ["switch", "media_player"]
     if create_sensors:
-        await async_load_platform(hass, 'sensor', DOMAIN, {}, config)
-    
-    await async_load_platform(hass, 'switch', DOMAIN, {}, config)
-    await async_load_platform(hass, 'media_player', DOMAIN, {}, config)
-
+        platforms.append("sensor")
+    await hass.config_entries.async_forward_entry_setups(entry, platforms)
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload AGS Service config entry."""
+    platforms = ["switch", "media_player", "sensor"]
+    await hass.config_entries.async_unload_platforms(entry, platforms)
+    hass.data[DOMAIN].pop(entry.entry_id, None)
+    return True
+
+
+async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle entry reload."""
+    await async_unload_entry(hass, entry)
+    await async_setup_entry(hass, entry)

--- a/custom_components/ags_service/config_flow.py
+++ b/custom_components/ags_service/config_flow.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import yaml
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import DOMAIN, DEVICE_SCHEMA
+
+
+class AGSServiceConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for AGS Service."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        self._errors: dict[str, str] = {}
+
+    async def async_step_user(self, user_input: dict | None = None):
+        """Handle the initial step."""
+        if user_input is not None:
+            try:
+                data = yaml.safe_load(user_input["configuration"])
+                DEVICE_SCHEMA(data)
+            except Exception:
+                self._errors["base"] = "invalid_yaml"
+            else:
+                return self.async_create_entry(title="AGS Service", data=data)
+        data_schema = vol.Schema({vol.Required("configuration"): str})
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=self._errors
+        )
+
+    async def async_step_import(self, user_input: dict):
+        """Import from YAML."""
+        try:
+            DEVICE_SCHEMA(user_input)
+        except Exception:
+            return self.async_abort(reason="invalid_import")
+        return self.async_create_entry(title="AGS Service", data=user_input)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        return AGSServiceOptionsFlow(config_entry)
+
+
+class AGSServiceOptionsFlow(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = entry
+        self._errors: dict[str, str] = {}
+
+    async def async_step_init(self, user_input: dict | None = None):
+        if user_input is not None:
+            try:
+                data = yaml.safe_load(user_input["configuration"])
+                DEVICE_SCHEMA(data)
+            except Exception:
+                self._errors["base"] = "invalid_yaml"
+            else:
+                return self.async_create_entry(data=data)
+        current = yaml.safe_dump(dict(self.config_entry.data))
+        data_schema = vol.Schema({vol.Required("configuration", default=current): str})
+        return self.async_show_form(
+            step_id="init", data_schema=data_schema, errors=self._errors
+        )

--- a/custom_components/ags_service/const.py
+++ b/custom_components/ags_service/const.py
@@ -1,0 +1,94 @@
+"""Constants for AGS Service."""
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+
+DOMAIN = "ags_service"
+
+CONF_ROOM = "room"
+CONF_ROOMS = "rooms"
+CONF_DEVICE_ID = "device_id"
+CONF_DEVICE_TYPE = "device_type"
+CONF_PRIORITY = "priority"
+CONF_OVERRIDE_CONTENT = "override_content"
+CONF_DISABLE_ZONE = "disable_zone"
+CONF_HOMEKIT_PLAYER = "homekit_player"
+CONF_CREATE_SENSORS = "create_sensors"
+CONF_DEFAULT_ON = "default_on"
+CONF_STATIC_NAME = "static_name"
+CONF_DISABLE_TV_SOURCE = "disable_Tv_Source"
+CONF_INTERVAL_SYNC = "interval_sync"
+CONF_SCHEDULE_ENTITY = "schedule_entity"
+CONF_OTT_DEVICE = "ott_device"
+CONF_OTT_DEVICES = "ott_devices"
+CONF_TV_INPUT = "tv_input"
+CONF_SOURCES = "Sources"
+CONF_SOURCE = "Source"
+CONF_MEDIA_CONTENT_TYPE = "media_content_type"
+CONF_SOURCE_VALUE = "Source_Value"
+CONF_SOURCE_DEFAULT = "source_default"
+
+DEVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_ROOMS): vol.All(
+        cv.ensure_list,
+        [
+            vol.Schema(
+                {
+                    vol.Required(CONF_ROOM): cv.string,
+                    vol.Required("devices"): vol.All(
+                        cv.ensure_list,
+                        [
+                            vol.Schema(
+                                {
+                                    vol.Required(CONF_DEVICE_ID): cv.string,
+                                    vol.Required(CONF_DEVICE_TYPE): cv.string,
+                                    vol.Required(CONF_PRIORITY): cv.positive_int,
+                                    vol.Optional(CONF_OVERRIDE_CONTENT): cv.string,
+                                    vol.Optional(CONF_OTT_DEVICES): vol.All(
+                                        cv.ensure_list,
+                                        [
+                                            vol.Schema(
+                                                {
+                                                    vol.Required(CONF_OTT_DEVICE): cv.string,
+                                                    vol.Required(CONF_TV_INPUT): cv.string,
+                                                    vol.Optional("default", default=False): cv.boolean,
+                                                }
+                                            )
+                                        ],
+                                    ),
+                                }
+                            )
+                        ],
+                    ),
+                }
+            )
+        ],
+    ),
+    vol.Required(CONF_SOURCES): vol.All(
+        cv.ensure_list,
+        [
+            vol.Schema(
+                {
+                    vol.Required(CONF_SOURCE): cv.string,
+                    vol.Required(CONF_SOURCE_VALUE): cv.string,
+                    vol.Required(CONF_MEDIA_CONTENT_TYPE): cv.string,
+                    vol.Optional(CONF_SOURCE_DEFAULT, default=False): cv.boolean,
+                }
+            )
+        ],
+    ),
+    vol.Optional(CONF_DISABLE_ZONE, default=False): cv.boolean,
+    vol.Optional(CONF_HOMEKIT_PLAYER, default=None): cv.string,
+    vol.Optional(CONF_CREATE_SENSORS, default=False): cv.boolean,
+    vol.Optional(CONF_DEFAULT_ON, default=False): cv.boolean,
+    vol.Optional(CONF_STATIC_NAME, default=None): cv.string,
+    vol.Optional(CONF_DISABLE_TV_SOURCE, default=False): cv.boolean,
+    vol.Optional(CONF_INTERVAL_SYNC, default=30): cv.positive_int,
+    vol.Optional(CONF_SCHEDULE_ENTITY): vol.Schema({
+        vol.Required("entity_id"): cv.string,
+        vol.Optional("on_state", default="on"): cv.string,
+        vol.Optional("off_state", default="off"): cv.string,
+        vol.Optional("schedule_override", default=False): cv.boolean,
+    }),
+})

--- a/custom_components/ags_service/manifest.json
+++ b/custom_components/ags_service/manifest.json
@@ -7,5 +7,6 @@
   "integration_type": "helper",
   "iot_class": "local_polling",
   "requirements": [],
-  "version": "1.5.0"
+  "version": "1.6.0",
+  "config_flow": true
 }

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -5,6 +5,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import STATE_IDLE, STATE_PLAYING, STATE_PAUSED
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.config_entries import ConfigEntry
 
 import asyncio
 from .ags_service import (
@@ -17,12 +18,14 @@ from .ags_service import (
 import logging
 _LOGGER = logging.getLogger(__name__)
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    ags_config = hass.data['ags_service']
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    ags_config = hass.data['ags_service'][entry.entry_id]
     rooms = ags_config['rooms']
     
 
-    ags_media_player = AGSPrimarySpeakerMediaPlayer(hass, ags_config)
+    ags_media_player = AGSPrimarySpeakerMediaPlayer(hass, ags_config, entry.entry_id)
     async_add_entities([ags_media_player])
     
     # Set up a listener to monitor changes to sensor.ags_primary_speaker
@@ -79,10 +82,11 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         if last_state:
             self.hass.data["ags_media_player_source"] = last_state.attributes.get("source")
 
-    def __init__(self, hass, ags_config):
+    def __init__(self, hass: HomeAssistant, ags_config: dict, entry_id: str):
         """Initialize the media player."""
         self._hass = hass
         self.ags_config = ags_config
+        self.entry_id = entry_id
         self._name = "AGS Media Player"
         self._state = STATE_IDLE
         self.primary_speaker_entity_id = None
@@ -142,7 +146,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         selected_source = self.hass.data.get('ags_media_player_source')
         if selected_source is None:
-            sources = self.hass.data['ags_service']['Sources']
+            sources = self.hass.data['ags_service'][self.entry_id]['Sources']
             default = next(
                 (
                     src["Source"]
@@ -231,7 +235,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
     @property
     def name(self):
-        ags_config = self.hass.data['ags_service']
+        ags_config = self.hass.data['ags_service'][self.entry_id]
         static_name = ags_config['static_name']
         if static_name: 
             return static_name 
@@ -412,7 +416,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
     @property
     def source_list(self):
         """List of available sources."""
-        ags_config = self.hass.data['ags_service']
+        ags_config = self.hass.data['ags_service'][self.entry_id]
         disable_Tv_Source = ags_config['disable_Tv_Source']
 
         if self.ags_status == "ON TV" and disable_Tv_Source == False:
@@ -424,9 +428,9 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         else:
             sources = [
                 source_dict["Source"]
-                for source_dict in self.hass.data["ags_service"]["Sources"]
+                for source_dict in self.hass.data["ags_service"][self.entry_id]["Sources"]
             ]
-            rooms = self.hass.data["ags_service"]["rooms"]
+            rooms = self.hass.data["ags_service"][self.entry_id]["rooms"]
             active_rooms = self.hass.data.get("active_rooms", [])
             has_active_tv_room = any(
                 room["room"] in active_rooms
@@ -447,7 +451,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
             return self.hass.data.get("ags_media_player_source")
 
     def get_source_value_by_name(self, source_name):
-        for source_dict in self.hass.data['ags_service']['Sources']:
+        for source_dict in self.hass.data['ags_service'][self.entry_id]['Sources']:
             if source_dict["Source"] == source_name:
                 return source_dict["Source_Value"]
         return None  # if not found
@@ -523,7 +527,7 @@ class MediaSystemMediaPlayer(MediaPlayerEntity):
     @property
     def name(self):
         """Return the name of the media system player."""
-        ags_config = self.hass.data['ags_service']
+        ags_config = self.hass.data['ags_service'][self.entry_id]
         return ags_config['homekit_player']
 
     @property
@@ -552,9 +556,9 @@ class MediaSystemMediaPlayer(MediaPlayerEntity):
     def source_list(self):
         sources = [
             source_dict["Source"]
-            for source_dict in self.hass.data["ags_service"]["Sources"]
+            for source_dict in self.hass.data["ags_service"][self.entry_id]["Sources"]
         ]
-        rooms = self.hass.data["ags_service"]["rooms"]
+        rooms = self.hass.data["ags_service"][self.entry_id]["rooms"]
         active_rooms = self.hass.data.get("active_rooms", [])
         has_active_tv_room = any(
             room["room"] in active_rooms

--- a/custom_components/ags_service/sensor.py
+++ b/custom_components/ags_service/sensor.py
@@ -10,13 +10,13 @@ SCAN_INTERVAL = timedelta(seconds=30)
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.config_entries import ConfigEntry
 # Setup platform function
 from homeassistant.helpers.event import async_track_state_change_event
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    # Create your sensors
-    ags_config = hass.data['ags_service']
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+    """Set up AGS sensors from a config entry."""
+    ags_config = hass.data['ags_service'][entry.entry_id]
     global SCAN_INTERVAL
     interval = ags_config.get('interval_sync', 30)
     SCAN_INTERVAL = timedelta(seconds=interval)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,5 @@
+import pytest
+
+
+def test_import_homeassistant():
+    pytest.importorskip("homeassistant")


### PR DESCRIPTION
## Summary
- convert AGS Service to use config entries
- add options flow and config import
- store per-entry data and implement reload handlers
- update README for UI configuration
- add minimal pytest and workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687163869ed88330a6f5e187eb490b0c