### PR TITLE
Add media browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The integration continuously tracks room occupancy and speaker states, regroupin
 **Virtual AGS Media Player**
 
 * Acts as the master player for the entire system. It automatically points to the best speaker based on room activity and exposes normal media controls (play, pause, volume, source, next/previous). Optionally a second HomeKit‑friendly player can mirror these controls for Apple users.
+* Exposes a **Media Browser** so you can explore favorites and sources from the active control device directly within Home Assistant. Selecting an item automatically calls `play_media` or `select_source` on that device.
 
 **Sensors**
 


### PR DESCRIPTION
## Summary
- expose `async_browse_media` in the AGS media player
- allow playing media items on the active control device
- forward media browser and playback calls in the HomeKit player
- document that media browser selections trigger `play_media` or `select_source`

## Testing
- `python -m py_compile custom_components/ags_service/media_player.py`
- `python -m py_compile custom_components/ags_service/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6871ee1bbeb0833085e04c6bc845985c