### PR TITLE
Implement per-TV tv_mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ AGS evaluates several conditions to decide when to play and which speaker should
 1. **update_ags_status** checks if `zone.home` is empty unless `disable_zone` is enabled. If nobody is home the status becomes `OFF`.
 2. When a `schedule_entity` is defined the status follows its state. With `schedule_override` disabled the system turns `OFF` whenever the schedule is off.
 3. Devices can define `override_content`. When a playing device's `media_content_id` contains this text the service switches to `Override` and that device becomes the primary speaker.
-4. If any active TV is on, status changes to `ON TV` and the integration records the active `tv_mode`.
-5. Rooms where every active TV is set to `tv_mode: no_music` are ignored until those TVs turn off.
+4. If any active TV is on with `tv_mode: tv_audio`, status changes to `ON TV` and the integration records the active `tv_mode`.
+5. Rooms where every active TV is set to `tv_mode: no_music` are ignored until those TVs turn off. When this is true for all active TVs, the status stays `ON`.
 6. Otherwise the status is simply `ON`.
 
 `determine_primary_speaker` sorts devices in each active room by priority and picks the first playing speaker. If none are found it immediately falls back to the preferred device.

--- a/custom_components/ags_service/__init__.py
+++ b/custom_components/ags_service/__init__.py
@@ -31,6 +31,10 @@ CONF_SOURCE = 'Source'
 CONF_MEDIA_CONTENT_TYPE = 'media_content_type'
 CONF_SOURCE_VALUE = 'Source_Value'
 CONF_SOURCE_DEFAULT = 'source_default'
+CONF_TV_MODE = 'tv_mode'
+
+TV_MODE_TV_AUDIO = 'tv_audio'
+TV_MODE_NO_MUSIC = 'no_music'
 
 
 # Define the configuration schema for a device
@@ -51,6 +55,7 @@ DEVICE_SCHEMA = vol.Schema({
                                     vol.Required("priority"): cv.positive_int,
                                     vol.Optional("override_content"): cv.string,
                                     vol.Optional(CONF_OTT_DEVICE): cv.string,
+                                    vol.Optional(CONF_TV_MODE): vol.In([TV_MODE_TV_AUDIO, TV_MODE_NO_MUSIC]),
                                 }
                             )
                         ],
@@ -93,13 +98,19 @@ async def async_setup(hass, config):
 
     ags_config = config[DOMAIN]
 
-    # Validate ott_device usage
+    # Validate ott_device and tv_mode usage
     for room in ags_config['rooms']:
         for device in room['devices']:
             if CONF_OTT_DEVICE in device and device['device_type'] != 'tv':
                 raise vol.Invalid(
                     "ott_device is only allowed for devices with device_type 'tv'"
                 )
+            if CONF_TV_MODE in device and device['device_type'] != 'tv':
+                raise vol.Invalid(
+                    "tv_mode is only allowed for devices with device_type 'tv'"
+                )
+            if device['device_type'] == 'tv' and CONF_TV_MODE not in device:
+                device[CONF_TV_MODE] = TV_MODE_TV_AUDIO
 
     hass.data[DOMAIN] = {
         'rooms': ags_config['rooms'],

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -3,6 +3,10 @@ import logging
 import asyncio
 from homeassistant.core import HomeAssistant
 
+CONF_TV_MODE = 'tv_mode'
+TV_MODE_TV_AUDIO = 'tv_audio'
+TV_MODE_NO_MUSIC = 'no_music'
+
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -194,13 +198,27 @@ def get_active_rooms(rooms, hass):
     """Fetch the list of active rooms based on switches in hass.data."""
     
     active_rooms = []
-    
+
     for room in rooms:
         room_key = f"switch.{room['room'].lower().replace(' ', '_')}_media"
-        
-        # If the room switch is found in hass.data, add the room to the active list
-        if hass.data.get(room_key):
-            active_rooms.append(room['room'])
+        if not hass.data.get(room_key):
+            continue
+
+        skip_room = False
+        for device in room['devices']:
+            if device.get('device_type') != 'tv':
+                continue
+            state = hass.states.get(device['device_id'])
+            if state and state.state != 'off':
+                if device.get('tv_mode', TV_MODE_TV_AUDIO) == TV_MODE_TV_AUDIO:
+                    skip_room = False
+                    break
+                else:
+                    skip_room = True
+        if skip_room:
+            continue
+
+        active_rooms.append(room['room'])
     
     # Store the list of active rooms in hass.data
     hass.data['active_rooms'] = active_rooms
@@ -318,16 +336,40 @@ def update_ags_status(ags_config, hass):
         return ags_status
 
 
-    # Check for TV in active rooms
+    # Check for TV in active rooms and determine global tv_mode
+    tv_found = False
+    active_tv_mode = None
     for room in rooms:
-        if room['room'] in active_rooms:
-            for device in room['devices']:
-                device_state = device_states.get(device['device_id'])
-                if device['device_type'] == 'tv' and device_state and device_state.state != 'off':
-                    ags_status = "ON TV"
-                    _handle_status_transition(prev_status, ags_status, hass)
-                    hass.data['ags_status'] = ags_status
-                    return ags_status
+        room_key = f"switch.{room['room'].lower().replace(' ', '_')}_media"
+        if not hass.data.get(room_key):
+            continue
+
+        room_tv_on = False
+        room_tv_audio = False
+        for device in room['devices']:
+            device_state = device_states.get(device['device_id'])
+            if (
+                device.get('device_type') == 'tv'
+                and device_state
+                and device_state.state != 'off'
+            ):
+                room_tv_on = True
+                if device.get('tv_mode', TV_MODE_TV_AUDIO) == TV_MODE_TV_AUDIO:
+                    room_tv_audio = True
+
+        if room_tv_on:
+            tv_found = True
+            if room_tv_audio:
+                active_tv_mode = TV_MODE_TV_AUDIO
+            elif active_tv_mode != TV_MODE_TV_AUDIO and active_tv_mode is None:
+                active_tv_mode = TV_MODE_NO_MUSIC
+
+    if tv_found:
+        ags_status = "ON TV"
+        hass.data['current_tv_mode'] = active_tv_mode
+        _handle_status_transition(prev_status, ags_status, hass)
+        hass.data['ags_status'] = ags_status
+        return ags_status
 
     ags_status = "ON"
     _handle_status_transition(prev_status, ags_status, hass)
@@ -825,11 +867,14 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
 
         # Source selection depends on the current status
         if new_status == "ON TV":
-            if "TV" in (state.attributes.get("source_list") or []) and actions_enabled:
-                if state.attributes.get("source") != "TV":
-                    await enqueue_media_action(
-                        hass, "select_source", {"entity_id": calculated, "source": "TV"}
-                    )
+            if hass.data.get("current_tv_mode", TV_MODE_TV_AUDIO) != TV_MODE_NO_MUSIC:
+                if "TV" in (state.attributes.get("source_list") or []) and actions_enabled:
+                    if state.attributes.get("source") != "TV":
+                        await enqueue_media_action(
+                            hass, "select_source", {"entity_id": calculated, "source": "TV"}
+                        )
+            else:
+                _LOGGER.debug("tv_mode set to no_music - skipping TV commands")
         else:
             if actions_enabled and (
                 state.state != "playing" or state.attributes.get("source") == "TV"

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -365,11 +365,12 @@ def update_ags_status(ags_config, hass):
                 active_tv_mode = TV_MODE_NO_MUSIC
 
     if tv_found:
-        ags_status = "ON TV"
         hass.data['current_tv_mode'] = active_tv_mode
-        _handle_status_transition(prev_status, ags_status, hass)
-        hass.data['ags_status'] = ags_status
-        return ags_status
+        if active_tv_mode != TV_MODE_NO_MUSIC:
+            ags_status = "ON TV"
+            _handle_status_transition(prev_status, ags_status, hass)
+            hass.data['ags_status'] = ags_status
+            return ags_status
 
     ags_status = "ON"
     _handle_status_transition(prev_status, ags_status, hass)

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -7,7 +7,12 @@ from homeassistant.const import STATE_IDLE
 from homeassistant.helpers.event import async_track_state_change_event
 
 import asyncio
-from .ags_service import update_ags_sensors, ags_select_source
+from .ags_service import (
+    update_ags_sensors,
+    ags_select_source,
+    TV_MODE_TV_AUDIO,
+    TV_MODE_NO_MUSIC,
+)
 
 import logging
 _LOGGER = logging.getLogger(__name__)
@@ -166,7 +171,13 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
             if found_room:
                 break
 
-        if self.ags_status == "ON TV" and self.primary_speaker_room:
+        tv_mode = self.hass.data.get("current_tv_mode", TV_MODE_TV_AUDIO)
+
+        if (
+            self.ags_status == "ON TV"
+            and tv_mode != TV_MODE_NO_MUSIC
+            and self.primary_speaker_room
+        ):
             selected_device_id = None
 
             sorted_devices = sorted(
@@ -407,8 +418,13 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
         ags_config = self.hass.data['ags_service']
         disable_Tv_Source = ags_config['disable_Tv_Source']
 
-        if self.ags_status == "ON TV" and not disable_Tv_Source:
-            sources = self.primary_speaker_state.attributes.get('source_list') if self.primary_speaker_state else None 
+        tv_mode = self.hass.data.get("current_tv_mode", TV_MODE_TV_AUDIO)
+        if (
+            self.ags_status == "ON TV"
+            and disable_Tv_Source == False
+            and tv_mode != TV_MODE_NO_MUSIC
+        ):
+            sources = self.primary_speaker_state.attributes.get('source_list') if self.primary_speaker_state else None
 
         else:
             sources = [source_dict["Source"] for source_dict in self.hass.data['ags_service']['Sources']]


### PR DESCRIPTION
## Summary
- add `tv_mode` config option and constants
- validate that `tv_mode` is only set on TVs and defaults to `tv_audio`
- skip rooms when all active TVs request `no_music`
- compute global `current_tv_mode` for ON TV status
- skip TV commands when `current_tv_mode` is `no_music`
- update media player logic and docs for `tv_mode`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871f563864c833088c90863ec88ce58