### PR TITLE
Fix source change during playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 - Stop commands always include a short delay to prevent lingering playback.
 - The active speaker list clears correctly once rooms turn off.
 
+### v1.5.1
+- Source changes from the AGS media player now ignore the playback check so
+  playlists switch instantly. Automation still waits for idle speakers.
+
 
 
 -### v1.4.1

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -571,7 +571,13 @@ def get_control_device_id(ags_config, hass):
 
 
 
-async def ags_select_source(ags_config, hass):
+async def ags_select_source(ags_config, hass, ignore_playing: bool = False):
+    """Select the configured music source on the primary speaker.
+
+    When ``ignore_playing`` is ``True`` the source changes even if the device
+    is already playing.  Otherwise the function returns early whenever a music
+    source is selected while playback is active.
+    """
 
     try:
         actions_enabled = hass.data.get("switch.ags_actions", True)
@@ -634,8 +640,13 @@ async def ags_select_source(ags_config, hass):
             )
 
         elif source != "Unknown" and status == "ON":
-            if state.state == "playing" and state.attributes.get("source") != "TV":
+            if (
+                not ignore_playing
+                and state.state == "playing"
+                and state.attributes.get("source") != "TV"
+            ):
                 return
+
             source_info = source_dict.get(source)
 
             if source_info:

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -454,7 +454,7 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         actions_enabled = self.hass.data.get("switch.ags_actions", True)
         if actions_enabled:
-            ags_select_source(self.ags_config, self.hass)
+            ags_select_source(self.ags_config, self.hass, ignore_playing=True)
         self._schedule_ags_update()
            
 


### PR DESCRIPTION
## Summary
- update changelog entry for v1.5.1
- only bypass playback check when source is changed via AGS media player
- keep playback guard for automatic source selection

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687211b10898833096d44ac2ee231dd7