### PR TITLE
Fix source change during playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 # Changelog
 
 
+### v1.5.1
+- Source changes from the AGS media player now ignore the playback check so
+  playlists switch instantly. Automations still wait for idle speakers.
+
 ### v1.5.0
 - **Breaking change**: replace `ott_device` with an `ott_devices` list that matches TV inputs and supports a `default: true` fallback.
 - Added `batch_unjoin` option to unjoin all speakers at once for faster shutdown.
@@ -254,9 +258,7 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 - Stop commands always include a short delay to prevent lingering playback.
 - The active speaker list clears correctly once rooms turn off.
 
-
-
--### v1.4.1
+### v1.4.1
 - Fixed stopping logic when turning the system off so every available speaker
   receives a stop or reset command.
 

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -571,7 +571,13 @@ def get_control_device_id(ags_config, hass):
 
 
 
-async def ags_select_source(ags_config, hass):
+async def ags_select_source(ags_config, hass, ignore_playing: bool = False):
+    """Select the configured music source on the primary speaker.
+
+    When ``ignore_playing`` is ``True`` the source changes even if the device
+    is already playing.  Otherwise the function returns early whenever a music
+    source is selected while playback is active.
+    """
 
     try:
         actions_enabled = hass.data.get("switch.ags_actions", True)
@@ -634,8 +640,13 @@ async def ags_select_source(ags_config, hass):
             )
 
         elif source != "Unknown" and status == "ON":
-            if state.state == "playing" and state.attributes.get("source") != "TV":
+            if (
+                not ignore_playing
+                and state.state == "playing"
+                and state.attributes.get("source") != "TV"
+            ):
                 return
+
             source_info = source_dict.get(source)
 
             if source_info:

--- a/custom_components/ags_service/media_player.py
+++ b/custom_components/ags_service/media_player.py
@@ -454,7 +454,15 @@ class AGSPrimarySpeakerMediaPlayer(MediaPlayerEntity, RestoreEntity):
 
         actions_enabled = self.hass.data.get("switch.ags_actions", True)
         if actions_enabled:
-            ags_select_source(self.ags_config, self.hass)
+            self.hass.loop.call_soon_threadsafe(
+                lambda: self.hass.async_create_task(
+                    ags_select_source(
+                        self.ags_config,
+                        self.hass,
+                        ignore_playing=True,
+                    )
+                )
+            )
         self._schedule_ags_update()
            
 


### PR DESCRIPTION
## Summary
- update changelog entry for v1.5.1
- keep changelog order latest first and fix v1.4.1 header formatting
- run ags_select_source asynchronously from media player so user source picks apply immediately

## Testing
- `pytest -q`
- `flake8` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687211b10898833096d44ac2ee231dd7