### PR TITLE
Fix repeated off actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ This project is released under a Non-Commercial License. See the [LICENSE](LICEN
 # Changelog
 
 
+### v1.5.2
+- Ignore repeated turn-off events so no extra stop commands fire once the system is off.
+
 ### v1.5.1
 - Source changes from the AGS media player now ignore the playback check so
   playlists switch instantly. Automations still wait for idle speakers.

--- a/custom_components/ags_service/ags_service.py
+++ b/custom_components/ags_service/ags_service.py
@@ -701,6 +701,10 @@ async def handle_ags_status_change(hass, ags_config, new_status, old_status):
         await wait_for_actions(hass)
         await hass.data["ags_service"]["update_event"].wait()
 
+        # Skip repeated "OFF" handling once the system is fully stopped
+        if new_status == "OFF" and old_status == "OFF":
+            return
+
         rooms = ags_config["rooms"]
         device_states = {s.entity_id: s for s in hass.states.async_all()}
         tv_map = {


### PR DESCRIPTION
## Summary
- avoid repeated off actions when AGS is already off
- document the change in the changelog

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688cf5b2341083308e6a97976580cabd